### PR TITLE
地図のクレジットの表記を修正

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -23,10 +23,10 @@ export default class extends Controller {
   setMap() {
     const centerPosition = [35.68032, 139.73946];
     const map = L.map("map").setView(centerPosition, 12);
-    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
       maxZoom: 19,
       attribution:
-        '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>Tiles Ⓒ <a href="">HOT</a>',
+        '&copy; <a href="https://www.openstreetmap.org/copyright/ja">OpenStreetMap</a>contributors',
     }).addTo(map);
     return map;
   }


### PR DESCRIPTION
- https://github.com/SuzukaHori/YamaNotes/issues/66

こちらで地図の差し替えを検討しましたが、実装の難易度や費用・駅の表示の見やすさの観点から差し替えは行わず、クレジットの誤りのみ修正しました。