### PR TITLE
内回りモードを追加

### DIFF
--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -3,7 +3,7 @@ class ArrivalsController < ApplicationController
   before_action :set_arrival, only: %i[show edit update destroy]
 
   def index
-    @arrivals = current_walk.arrivals
+    @arrivals = current_walk.sorted_arrivals
   end
 
   def show

--- a/app/controllers/walks_controller.rb
+++ b/app/controllers/walks_controller.rb
@@ -8,6 +8,7 @@ class WalksController < ApplicationController
 
   def new
     @walk = Walk.new
+    @arrival = Arrival.new
   end
 
   def create
@@ -15,9 +16,8 @@ class WalksController < ApplicationController
       redirect_to walk_url, alert: '歩行記録は一つしか作成できません'
       return
     end
-    walk = current_user.build_walk(clockwise: params[:clockwise])
-    arrival = walk.arrivals.new(station_id: params[:station_id], arrived_at: Time.current)
-    if walk.save && arrival.save
+    @walk = current_user.build_walk(clockwise: params[:clockwise])
+    if @walk.save && @walk.arrivals.create(station_id: params[:station_id], arrived_at: Time.current)
       redirect_to walk_url, notice: '歩行記録の作成に成功しました'
     else
       render :new, status: :unprocessable_entity

--- a/app/helpers/walks_helper.rb
+++ b/app/helpers/walks_helper.rb
@@ -12,7 +12,8 @@ module WalksHelper
   end
 
   def total_distance_walked
-    current_walk.arrivals_without_departure.map(&:station).sum(&:clockwise_distance_to_next).round(2)
+    distance_to_next_station = current_walk.arrived_stations.last.clockwise_distance_to_next
+    (current_walk.arrived_stations.sum(&:clockwise_distance_to_next) - distance_to_next_station).round(2)
   end
 
   def elapsed_time

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -5,7 +5,7 @@ class Arrival < ApplicationRecord
   validate :prohibit_arrival_without_next_station
 
   def prohibit_arrival_without_next_station
-    return if walk.arrivals.length == 1
+    return if walk.arrivals.length <= 1
 
     is_correct_next_station =
       if walk.clockwise

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -2,4 +2,19 @@ class Arrival < ApplicationRecord
   belongs_to :walk
   belongs_to :station
   validates :arrived_at, presence: true
+  validate :prohibit_arrival_without_next_station
+
+  def prohibit_arrival_without_next_station
+    return if walk.arrivals.length == 1
+
+    is_correct_next_station =
+      if walk.clockwise
+        walk.current_station.clockwise_next_station == station
+      else
+        station == Station.find_by(clockwise_next_station: walk.current_station)
+      end
+    return if is_correct_next_station
+
+    errors.add :station_id, '隣駅以外に到着することはできません'
+  end
 end

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -5,7 +5,7 @@ class Arrival < ApplicationRecord
   validate :prohibit_arrival_without_next_station
 
   def prohibit_arrival_without_next_station
-    return if walk.arrivals.length <= 1
+    return if walk.arrivals.empty?
 
     is_correct_next_station =
       if walk.clockwise

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -4,7 +4,7 @@ class Station < ApplicationRecord
   has_one :station, class_name: 'Station', inverse_of: :clockwise_next_station, dependent: :destroy
   belongs_to :clockwise_next_station, class_name: 'Station', inverse_of: :station
 
-  def next(clockwise)
+  def next(clockwise:)
     if clockwise
       next_id = id == Station.all.map(&:id).max ? 1 : id + 1
       Station.find(next_id)

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,6 +1,8 @@
 class Station < ApplicationRecord
   has_many :arrivals, dependent: :destroy
   has_many :walks, through: :arrivals
+  has_one :station, class_name: 'Station', inverse_of: :clockwise_next_station, dependent: :destroy
+  belongs_to :clockwise_next_station, class_name: 'Station', inverse_of: :station
 
   def next
     next_id = id == Station.all.map(&:id).max ? 1 : id + 1

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -4,9 +4,13 @@ class Station < ApplicationRecord
   has_one :station, class_name: 'Station', inverse_of: :clockwise_next_station, dependent: :destroy
   belongs_to :clockwise_next_station, class_name: 'Station', inverse_of: :station
 
-  def next
-    next_id = id == Station.all.map(&:id).max ? 1 : id + 1
-    Station.find(next_id)
+  def next(clockwise)
+    if clockwise
+      next_id = id == Station.all.map(&:id).max ? 1 : id + 1
+      Station.find(next_id)
+    else
+      Station.find_by(clockwise_next_station: self)
+    end
   end
 
   def self.total_distance

--- a/app/models/walk.rb
+++ b/app/models/walk.rb
@@ -16,13 +16,13 @@ class Walk < ApplicationRecord
     sorted_arrivals.slice(1..-1)
   end
 
+  def sorted_arrivals
+    arrivals.order(arrived_at: :asc)
+  end
+
   private
 
   def departure_station
     arrivals.order(:created_at).first.station
-  end
-
-  def sorted_arrivals
-    arrivals.order(arrived_at: :asc)
   end
 end

--- a/app/views/walks/new.html.slim
+++ b/app/views/walks/new.html.slim
@@ -1,4 +1,5 @@
 = render 'shared/errors', model: @walk
+= render 'shared/errors', model: @arrival
 
 = form_with url: walk_path, method: :post do |f|
   = f.radio_button :clockwise, true, checked: true

--- a/app/views/walks/show.html.slim
+++ b/app/views/walks/show.html.slim
@@ -14,7 +14,7 @@ br
 .current-info
   p 現在の駅  ：#{@walk.current_station.name}駅
   p 次の駅まで：#{@walk.current_station.clockwise_distance_to_next}km
-  p style="display: inline;" 次の駅   ： #{@walk.current_station.next.name}駅
+  p style="display: inline;" 次の駅   ： #{@walk.current_station.next(@walk.clockwise).name}駅
   .inline-flex.ml-2
     = button_to '到着', arrivals_path,
-      params: { station_id: @walk.current_station.next.id }, class: 'btn-primary'
+      params: { station_id: @walk.current_station.next(@walk.clockwise).id }, class: 'btn-primary'

--- a/app/views/walks/show.html.slim
+++ b/app/views/walks/show.html.slim
@@ -14,7 +14,7 @@ br
 .current-info
   p 現在の駅  ：#{@walk.current_station.name}駅
   p 次の駅まで：#{@walk.current_station.clockwise_distance_to_next}km
-  p style="display: inline;" 次の駅   ： #{@walk.current_station.next(@walk.clockwise).name}駅
+  p style="display: inline;" 次の駅   ： #{@walk.current_station.next(clockwise: @walk.clockwise).name}駅
   .inline-flex.ml-2
     = button_to '到着', arrivals_path,
-      params: { station_id: @walk.current_station.next(@walk.clockwise).id }, class: 'btn-primary'
+      params: { station_id: @walk.current_station.next(clockwise: @walk.clockwise).id }, class: 'btn-primary'

--- a/db/migrate/20240323054336_create_stations.rb
+++ b/db/migrate/20240323054336_create_stations.rb
@@ -5,7 +5,7 @@ class CreateStations < ActiveRecord::Migration[7.1]
       t.float :longitude, null: false
       t.float :latitude, null: false
       t.float :clockwise_distance_to_next, null: false
-      t.float :counterclockwise_distance_to_next, null: false
+      t.integer :clockwise_next_station_id
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_23_055616) do
     t.float "longitude", null: false
     t.float "latitude", null: false
     t.float "clockwise_distance_to_next", null: false
-    t.float "counterclockwise_distance_to_next", null: false
+    t.integer "clockwise_next_station_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,18 +33,20 @@ stations = [
   { name: '高輪ゲートウェイ', latitude: 35.63569, longitude: 139.74044, clockwise_distance_to_next: 0.9 }
 ]
 
-stations.each do |station|
-  Station.create!(
-    id: station[:id],
-    name: station[:name],
-    latitude: station[:latitude],
-    longitude: station[:longitude],
-    clockwise_distance_to_next: station[:clockwise_distance_to_next],
-  )
-end
+if Station.all.empty?
+  stations_instances = stations.map do |station|
+    Station.new(
+      name: station[:name],
+      latitude: station[:latitude],
+      longitude: station[:longitude],
+      clockwise_distance_to_next: station[:clockwise_distance_to_next]
+    )
+  end
 
-Station.all.each_with_index do |station, i|
-  next_id = i < 29 ? i + 2 : (i + 2) - 30
-  station.clockwise_next_station_id = next_id
-  station.save!
+  stations_instances.each_with_index do |station, i|
+    next_id = i > 28 ? i - 28 : i + 2
+    station.clockwise_next_station_id = next_id
+  end
+
+  stations_instances.each { |station| station.save!(validate: false) }
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,36 +1,36 @@
 # frozen_string_literal: true
 
 stations = [
-  { name: '品川', latitude: 35.628471, longitude: 139.73876, clockwise_distance_to_next: 2.0, counterclockwise_distance_to_next: 0.9 },
-  { name: '大崎', latitude: 35.6197, longitude: 139.728553, clockwise_distance_to_next: 0.9, counterclockwise_distance_to_next: 2.0 },
-  { name: '五反田', latitude: 35.625974, longitude: 139.723188, clockwise_distance_to_next: 1.2, counterclockwise_distance_to_next: 0.9 },
-  { name: '目黒', latitude: 35.633998, longitude: 139.715828, clockwise_distance_to_next: 1.5, counterclockwise_distance_to_next: 1.2 },
-  { name: '恵比寿', latitude: 35.64669, longitude: 139.710106, clockwise_distance_to_next: 1.6, counterclockwise_distance_to_next: 1.5 },
-  { name: '渋谷', latitude: 35.658034, longitude: 139.701636, clockwise_distance_to_next: 1.2, counterclockwise_distance_to_next: 1.6 },
-  { name: '原宿', latitude: 35.670168, longitude: 139.702687, clockwise_distance_to_next: 1.5, counterclockwise_distance_to_next: 1.2 },
-  { name: '代々木', latitude: 35.683061, longitude: 139.702042, clockwise_distance_to_next: 0.7, counterclockwise_distance_to_next: 1.5 },
-  { name: '新宿', latitude: 35.689596, longitude: 139.700429, clockwise_distance_to_next: 1.3, counterclockwise_distance_to_next: 0.7 },
-  { name: '新大久保', latitude: 35.700429, longitude: 139.700218, clockwise_distance_to_next: 1.4, counterclockwise_distance_to_next: 1.3 },
-  { name: '高田馬場', latitude: 35.712285, longitude: 139.703782, clockwise_distance_to_next: 0.9, counterclockwise_distance_to_next: 1.4 },
-  { name: '目白', latitude: 35.721204, longitude: 139.706587, clockwise_distance_to_next: 1.2, counterclockwise_distance_to_next: 0.9 },
-  { name: '池袋', latitude: 35.729503, longitude: 139.7109, clockwise_distance_to_next: 1.8, counterclockwise_distance_to_next: 1.2 },
-  { name: '大塚', latitude: 35.731412, longitude: 139.729025, clockwise_distance_to_next: 0.7, counterclockwise_distance_to_next: 1.8 },
-  { name: '巣鴨', latitude: 35.733445, longitude: 139.739345, clockwise_distance_to_next: 1.1, counterclockwise_distance_to_next: 0.7 },
-  { name: '駒込', latitude: 35.736489, longitude: 139.746875, clockwise_distance_to_next: 1.6, counterclockwise_distance_to_next: 1.1 },
-  { name: '田端', latitude: 35.738062, longitude: 139.76086, clockwise_distance_to_next: 0.8, counterclockwise_distance_to_next: 1.6 },
-  { name: '西日暮里', latitude: 35.732135, longitude: 139.766787, clockwise_distance_to_next: 0.5, counterclockwise_distance_to_next: 0.8 },
-  { name: '日暮里', latitude: 35.727772, longitude: 139.770987, clockwise_distance_to_next: 1.1, counterclockwise_distance_to_next: 0.5 },
-  { name: '鶯谷', latitude: 35.721204, longitude: 139.778015, clockwise_distance_to_next: 1.1, counterclockwise_distance_to_next: 1.1 },
-  { name: '上野', latitude: 35.713768, longitude: 139.777254, clockwise_distance_to_next: 0.6, counterclockwise_distance_to_next: 1.1 },
-  { name: '御徒町', latitude: 35.707438, longitude: 139.774632, clockwise_distance_to_next: 1.0, counterclockwise_distance_to_next: 0.6 },
-  { name: '秋葉原', latitude: 35.698683, longitude: 139.774219, clockwise_distance_to_next: 0.7, counterclockwise_distance_to_next: 1.0 },
-  { name: '神田', latitude: 35.69169, longitude: 139.770883, clockwise_distance_to_next: 1.3, counterclockwise_distance_to_next: 0.7 },
-  { name: '東京', latitude: 35.681391, longitude: 139.766103, clockwise_distance_to_next: 0.8, counterclockwise_distance_to_next: 1.3 },
-  { name: '有楽町', latitude: 35.675069, longitude: 139.763328, clockwise_distance_to_next: 1.1, counterclockwise_distance_to_next: 0.8 },
-  { name: '新橋', latitude: 35.665498, longitude: 139.75964, clockwise_distance_to_next: 1.2, counterclockwise_distance_to_next: 1.1 },
-  { name: '浜松町', latitude: 35.655646, longitude: 139.757272, clockwise_distance_to_next: 1.5, counterclockwise_distance_to_next: 1.2 },
-  { name: '田町', latitude: 35.645736, longitude: 139.747575, clockwise_distance_to_next: 1.3, counterclockwise_distance_to_next: 1.5 },
-  { name: '高輪ゲートウェイ', latitude: 35.63569, longitude: 139.74044, clockwise_distance_to_next: 0.9, counterclockwise_distance_to_next: 1.3 }
+  { name: '品川', latitude: 35.628471, longitude: 139.73876, clockwise_distance_to_next: 2.0 },
+  { name: '大崎', latitude: 35.6197, longitude: 139.728553, clockwise_distance_to_next: 0.9 },
+  { name: '五反田', latitude: 35.625974, longitude: 139.723188, clockwise_distance_to_next: 1.2 },
+  { name: '目黒', latitude: 35.633998, longitude: 139.715828, clockwise_distance_to_next: 1.5 },
+  { name: '恵比寿', latitude: 35.64669, longitude: 139.710106, clockwise_distance_to_next: 1.6 },
+  { name: '渋谷', latitude: 35.658034, longitude: 139.701636, clockwise_distance_to_next: 1.2 },
+  { name: '原宿', latitude: 35.670168, longitude: 139.702687, clockwise_distance_to_next: 1.5 },
+  { name: '代々木', latitude: 35.683061, longitude: 139.702042, clockwise_distance_to_next: 0.7 },
+  { name: '新宿', latitude: 35.689596, longitude: 139.700429, clockwise_distance_to_next: 1.3 },
+  { name: '新大久保', latitude: 35.700429, longitude: 139.700218, clockwise_distance_to_next: 1.4 },
+  { name: '高田馬場', latitude: 35.712285, longitude: 139.703782, clockwise_distance_to_next: 0.9 },
+  { name: '目白', latitude: 35.721204, longitude: 139.706587, clockwise_distance_to_next: 1.2 },
+  { name: '池袋', latitude: 35.729503, longitude: 139.7109, clockwise_distance_to_next: 1.8 },
+  { name: '大塚', latitude: 35.731412, longitude: 139.729025, clockwise_distance_to_next: 0.7 },
+  { name: '巣鴨', latitude: 35.733445, longitude: 139.739345, clockwise_distance_to_next: 1.1 },
+  { name: '駒込', latitude: 35.736489, longitude: 139.746875, clockwise_distance_to_next: 1.6 },
+  { name: '田端', latitude: 35.738062, longitude: 139.76086, clockwise_distance_to_next: 0.8 },
+  { name: '西日暮里', latitude: 35.732135, longitude: 139.766787, clockwise_distance_to_next: 0.5 },
+  { name: '日暮里', latitude: 35.727772, longitude: 139.770987, clockwise_distance_to_next: 1.1 },
+  { name: '鶯谷', latitude: 35.721204, longitude: 139.778015, clockwise_distance_to_next: 1.1 },
+  { name: '上野', latitude: 35.713768, longitude: 139.777254, clockwise_distance_to_next: 0.6 },
+  { name: '御徒町', latitude: 35.707438, longitude: 139.774632, clockwise_distance_to_next: 1.0 },
+  { name: '秋葉原', latitude: 35.698683, longitude: 139.774219, clockwise_distance_to_next: 0.7 },
+  { name: '神田', latitude: 35.69169, longitude: 139.770883, clockwise_distance_to_next: 1.3 },
+  { name: '東京', latitude: 35.681391, longitude: 139.766103, clockwise_distance_to_next: 0.8 },
+  { name: '有楽町', latitude: 35.675069, longitude: 139.763328, clockwise_distance_to_next: 1.1 },
+  { name: '新橋', latitude: 35.665498, longitude: 139.75964, clockwise_distance_to_next: 1.2 },
+  { name: '浜松町', latitude: 35.655646, longitude: 139.757272, clockwise_distance_to_next: 1.5 },
+  { name: '田町', latitude: 35.645736, longitude: 139.747575, clockwise_distance_to_next: 1.3 },
+  { name: '高輪ゲートウェイ', latitude: 35.63569, longitude: 139.74044, clockwise_distance_to_next: 0.9 }
 ]
 
 stations.each do |station|
@@ -40,6 +40,11 @@ stations.each do |station|
     latitude: station[:latitude],
     longitude: station[:longitude],
     clockwise_distance_to_next: station[:clockwise_distance_to_next],
-    counterclockwise_distance_to_next: station[:counterclockwise_distance_to_next]
   )
+end
+
+Station.all.each_with_index do |station, i|
+  next_id = i < 29 ? i + 2 : (i + 2) - 30
+  station.clockwise_next_station_id = next_id
+  station.save!
 end

--- a/spec/models/arrival_spec.rb
+++ b/spec/models/arrival_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Arrival, type: :model do
     end
 
     it '近接しない駅には到着できない' do
-      expect {
+      expect do
         @walk.arrivals.create!(station_id: 13, arrived_at: Time.current)
-      }.to raise_error(ActiveRecord::RecordInvalid)
+      end.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 end

--- a/spec/models/arrival_spec.rb
+++ b/spec/models/arrival_spec.rb
@@ -14,17 +14,9 @@ RSpec.describe Arrival, type: :model do
     end
 
     it '近接しない駅には到着できない' do
-      # TODO: add validation
-      # expect {
-      #   @walk.reload.arrivals.create!(station_id: 13, arrived_at: Time.current)
-      # }.to change { Arrival.count }.by(1)
-    end
-
-    it '一周終了時に最初の駅の到着時刻を更新する' do
-      (2..30).each do |n|
-        @walk.arrivals.create!(station_id: n, arrived_at: Time.current)
-      end
-      @arrival.update!(station_id: 1, arrived_at: Time.current)
+      expect {
+        @walk.arrivals.create!(station_id: 13, arrived_at: Time.current)
+      }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 end

--- a/spec/models/walk_spec.rb
+++ b/spec/models/walk_spec.rb
@@ -1,39 +1,70 @@
 require 'rails_helper'
 
 RSpec.describe Walk, type: :model do
-  before do
-    @walk = FactoryBot.create(:walk)
-    @arrival = @walk.arrivals.create!(station_id: 1, arrived_at: Time.current)
-  end
-
   describe '現在の駅を取得する' do
-    it '到着済みの駅がない時、出発駅が現在の駅になる' do
-      expect(@walk.current_station.name).to eq '品川'
+    context '外回りモードの時' do
+      before do
+        @walk = FactoryBot.create(:walk)
+        @arrival = @walk.arrivals.create!(station_id: 1, arrived_at: Time.current)
+      end
+
+      it '出発時に現在の駅を取得する' do
+        expect(@walk.current_station.name).to eq '品川'
+      end
+
+      it '複数の駅に到着後、現在の駅を取得する' do
+        create_arrivals(29)
+        expect(@walk.current_station.name).to eq '高輪ゲートウェイ'
+      end
     end
 
-    it '複数の駅に到着済みの時、直近で到着した駅が現在の駅になる' do
-      create_arrivals(29)
-      expect(@walk.current_station.name).to eq '高輪ゲートウェイ'
+    context '内回りモードの時' do
+      before do
+        @walk = FactoryBot.create(:walk, clockwise: false)
+        @arrival = @walk.arrivals.create!(station_id: 1, arrived_at: Time.current)
+      end
+
+      it '出発時に現在の駅を取得する' do
+        expect(@walk.current_station.name).to eq '品川'
+      end
+
+      it '複数の駅に到着後、現在の駅を取得する' do
+        create_arrivals(29)
+        expect(@walk.current_station.name).to eq '大崎'
+      end
     end
   end
 
-  describe '到着駅を取得する' do
-    it 'スタート時には出発駅のみの配列が返る' do
-      expect(@walk.arrived_stations.map(&:id)).to eq([1])
+  describe '到着駅一覧を取得する' do
+    context '外回りモードの時' do
+      before do
+        @walk = FactoryBot.create(:walk)
+        @arrival = @walk.arrivals.create!(station_id: 1, arrived_at: Time.current)
+      end
+
+      it '出発直後に到着駅一覧を取得する' do
+        expect(@walk.arrived_stations.map(&:id)).to eq([1])
+      end
+
+      it '複数の駅に到着後、到着駅一覧を取得する' do
+        create_arrivals(29)
+        expect(@walk.arrived_stations.length).to eq(30)
+      end
     end
 
-    it '複数の駅に到着済みの時、駅の配列が返る' do
-      create_arrivals(29)
-      expect(@walk.arrived_stations.length).to eq(30)
-    end
-  end
+    context '内回りモードの時' do
+      before do
+        @walk = FactoryBot.create(:walk, clockwise: false)
+        @arrival = @walk.arrivals.create!(station_id: 1, arrived_at: Time.current)
+      end
 
-  def create_arrivals(number)
-    (1..number).each do |n|
-      if n == 30
-        @walk.arrivals.create!(station_id: 1, arrived_at: Time.current)
-      else
-        @walk.arrivals.create!(station_id: n + 1, arrived_at: Time.current)
+      it '出発直後に到着駅一覧を取得する' do
+        expect(@walk.arrived_stations.map(&:id)).to eq([1])
+      end
+
+      it '複数の駅に到着後、到着駅一覧を取得する' do
+        create_arrivals(29)
+        expect(@walk.arrived_stations.length).to eq(30)
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -68,4 +68,5 @@ RSpec.configure do |config|
   end
 
   config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include WalkHelpers
 end

--- a/spec/support/walk_helper.rb
+++ b/spec/support/walk_helper.rb
@@ -1,0 +1,8 @@
+module WalkHelpers
+  def create_arrivals(number)
+    number.times do
+      next_station = @walk.current_station.next(clockwise: @walk.clockwise)
+      @walk.arrivals.create!(station: next_station, arrived_at: Time.current)
+    end
+  end
+end

--- a/spec/system/arrivals_spec.rb
+++ b/spec/system/arrivals_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe 'Arrivals', type: :system, js: true do
     start_walk
     click_on '到着'
     expect(page).to have_content('大崎駅に到着しました')
-    expect(page).to have_content('歩いた駅は1駅（残り29駅）、 歩いた距離は約0.9kmです！')
+    expect(page).to have_content('歩いた駅は1駅（残り29駅）、 歩いた距離は約2.0kmです！')
     click_on '地図に戻る'
     click_on '到着'
     expect(page).to have_content('五反田駅に到着しました')
-    expect(page).to have_content('歩いた駅は2駅（残り28駅）、 歩いた距離は約2.1kmです！')
+    expect(page).to have_content('歩いた駅は2駅（残り28駅）、 歩いた距離は約2.9kmです！')
   end
 
   scenario '到着時に現在の駅の情報が更新される' do
@@ -44,6 +44,18 @@ RSpec.describe 'Arrivals', type: :system, js: true do
     click_on '地図に戻る'
     expect(page).to have_content('現在の駅 ：大崎駅')
     expect(page).to have_content('次の駅まで：0.9km')
+  end
+
+  scenario '内回りモードで正しい駅に到着できる' do
+    visit new_walk_path
+    choose '内回り'
+    select '原宿'
+    click_on 'はじめる'
+    expect(page).to have_content('現在の駅 ：原宿駅')
+    click_on '到着'
+    expect(page).to have_content('渋谷駅に到着しました')
+    click_on '地図に戻る'
+    expect(page).to have_content('現在の駅 ：渋谷駅')
   end
 
   def start_walk

--- a/spec/system/walks_spec.rb
+++ b/spec/system/walks_spec.rb
@@ -21,6 +21,6 @@ RSpec.describe 'Walks', type: :system do
     click_on 'はじめる'
     expect(page).to have_content('出発から：0時間0分')
     expect(page).to have_content('歩いた駅：0駅（残り30駅）')
-    expect(page).to have_content('歩いた距離：約0km（残り34.5km）')
+    expect(page).to have_content('歩いた距離：約0.0km（残り34.5km）')
   end
 end


### PR DESCRIPTION
内回り（反時計回り）ができるようにしました。
- https://github.com/SuzukaHori/YamaNotes/issues/55
[![Image from Gyazo](https://i.gyazo.com/58c8fc17c80f6f454eaf47cc82f46723.gif)](https://gyazo.com/58c8fc17c80f6f454eaf47cc82f46723)

追加の過程で、データベースに以下の変更を行いました。
- Stationにclckwise_next_station_idを追加。
- Stationからcounterclockwise_distance_to_nextを削除。

https://github.com/SuzukaHori/YamaNotes/issues/3#issuecomment-2038762936