### PR TITLE
到着履歴の編集・削除機能を追加

### DIFF
--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -1,7 +1,7 @@
 class ArrivalsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_arrival, only: %i[show edit update destroy]
-  before_action :set_walk, only: [:index, :show, :create]
+  before_action :set_walk, only: %i[index show create]
 
   def index
     @arrivals = current_walk.sorted_arrivals
@@ -24,7 +24,7 @@ class ArrivalsController < ApplicationController
     if @arrival.update(arrival_params)
       redirect_to request.referer, notice: '到着記録を更新しました'
     else
-      render 'walks/show', status: :unprocessable_entity
+      render 'edit', status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -22,7 +22,9 @@ class ArrivalsController < ApplicationController
 
   def update
     if @arrival.update(arrival_params)
-      redirect_to request.referer, notice: '到着記録を更新しました'
+      # redirect_to request.referer, notice: '到着記録を更新しました'
+      @walk = current_walk
+      @arrivals = current_walk.arrivals.order(:id)
     else
       render 'edit', status: :unprocessable_entity
     end

--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -28,7 +28,13 @@ class ArrivalsController < ApplicationController
     end
   end
 
-  def destroy; end
+  def destroy
+    if @arrival.destroy
+      redirect_to arrivals_path, notice: '到着記録を削除しました'
+    else
+      render :index
+    end
+  end
 
   private
 

--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -1,7 +1,7 @@
 class ArrivalsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_arrival, only: %i[show edit update destroy]
-  before_action :set_walk, only: %i[index show create]
+  before_action :set_walk, only: %i[index show create update]
 
   def index
     @arrivals = current_walk.sorted_arrivals
@@ -22,8 +22,7 @@ class ArrivalsController < ApplicationController
 
   def update
     if @arrival.update(arrival_params)
-      # redirect_to request.referer, notice: '到着記録を更新しました'
-      @walk = current_walk
+      flash.now.notice = '到着記録を更新しました'
       @arrivals = current_walk.arrivals.order(:id)
     else
       render 'edit', status: :unprocessable_entity

--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -12,7 +12,7 @@ class ArrivalsController < ApplicationController
   def edit; end
 
   def create
-    @arrival = current_walk.arrivals.new(station_id: params[:station_id], arrived_at: Time.current)
+    @arrival = current_walk.arrivals.new(station_id: params[:station_id], arrived_at: Time.current.beginning_of_minute)
     if @arrival.save
       redirect_to @arrival
     else

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -68,6 +68,9 @@ export default class extends Controller {
       const station = stations[i];
       locations.push([station.latitude, station.longitude]);
     }
+    if (stations.length === this.allStations.length) {
+      locations.push([stations[0].latitude, stations[0].longitude]);
+    }
     L.polyline(locations, { color, weight: 15, opacity: 0.4 }).addTo(map);
   }
 }

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -3,21 +3,27 @@ class Arrival < ApplicationRecord
   belongs_to :station
   validates :arrived_at, presence: true
   validate :prohibit_arrival_without_next_station, if: -> { validation_context == :create }
-  before_validation :convert_blank_to_nil
   validate :check_arrived_time, if: -> { validation_context == :update }
+  before_validation :convert_blank_to_nil
   before_destroy :check_arrival_location, unless: -> { destroyed_by_association }
 
   private
 
   def check_arrived_time
+    errors.add :arrived_at, 'に未来の時刻は設定できません' if !arrived_at_earlier_than_now?
+    errors.add :arrived_at, 'は一つ前の到着時刻より前、一つ後ろの到着時間より後の時刻を設定してください' if !arrived_at_within_range?
+  end
+
+  def arrived_at_earlier_than_now?
+    arrived_at < Time.current
+  end
+
+  def arrived_at_within_range?
     arrivals = walk.arrivals.order(:id)
     self_index = arrivals.find_index(self)
     next_arrival_time = arrivals[self_index + 1]&.arrived_at
     prev_arrival_time = self_index.zero? ? nil : arrivals[self_index - 1].arrived_at
-
-    return if (prev_arrival_time..next_arrival_time).cover? arrived_at
-
-    errors.add :arrived_at, 'は一つ前の到着時刻より前、一つ後ろの到着時間より後の時刻を設定してください'
+    (prev_arrival_time..next_arrival_time).cover? arrived_at
   end
 
   def prohibit_arrival_without_next_station

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -4,9 +4,20 @@ class Arrival < ApplicationRecord
   validates :arrived_at, presence: true
   validate :prohibit_arrival_without_next_station, if: -> { validation_context == :create }
   before_validation :convert_blank_to_nil
+  validate :check_arrived_time, if: -> { validation_context == :update }
   before_destroy :check_arrival_location, unless: -> { destroyed_by_association }
 
   private
+
+  def check_arrived_time
+    arrivals = walk.arrivals.order(arrived_at: :asc)
+    self_index = arrivals.find_index(self)
+    next_arrival_time = arrivals[self_index + 1]&.arrived_at
+    prev_arrival_time = arrivals[self_index - 1].arrived_at
+    return if (prev_arrival_time..next_arrival_time).cover? arrived_at
+
+    errors.add :arrived_at, '到着時間が不正です'
+  end
 
   def prohibit_arrival_without_next_station
     return if walk.arrivals.empty?
@@ -27,7 +38,6 @@ class Arrival < ApplicationRecord
   end
 
   def check_arrival_location
-    return if destroyed_by_association
     return if self == walk.arrivals.order(:arrived_at).last
 
     errors.add :station_id, '最後の到着以外は削除できません'

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -10,13 +10,14 @@ class Arrival < ApplicationRecord
   private
 
   def check_arrived_time
-    arrivals = walk.arrivals.order(arrived_at: :asc)
+    arrivals = walk.arrivals.order(:id)
     self_index = arrivals.find_index(self)
     next_arrival_time = arrivals[self_index + 1]&.arrived_at
-    prev_arrival_time = arrivals[self_index - 1].arrived_at
+    prev_arrival_time = self_index.zero? ? nil : arrivals[self_index - 1].arrived_at
+
     return if (prev_arrival_time..next_arrival_time).cover? arrived_at
 
-    errors.add :arrived_at, '到着時間が不正です'
+    errors.add :arrived_at, 'は一つ前の到着時刻より前、一つ後ろの到着時間より後の時刻を設定してください'
   end
 
   def prohibit_arrival_without_next_station
@@ -38,7 +39,7 @@ class Arrival < ApplicationRecord
   end
 
   def check_arrival_location
-    return if self == walk.arrivals.order(:arrived_at).last
+    return if self == walk.sorted_arrivals.last
 
     errors.add :station_id, '最後の到着以外は削除できません'
     throw(:abort)

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -4,6 +4,9 @@ class Arrival < ApplicationRecord
   validates :arrived_at, presence: true
   validate :prohibit_arrival_without_next_station, if: -> { validation_context == :create }
   before_validation :convert_blank_to_nil
+  before_destroy :check_arrival_location
+
+  private
 
   def prohibit_arrival_without_next_station
     return if walk.arrivals.empty?
@@ -21,5 +24,12 @@ class Arrival < ApplicationRecord
 
   def convert_blank_to_nil
     self.memo = nil if memo.blank?
+  end
+
+  def check_arrival_location
+    return if self == walk.arrivals.order(:arrived_at).last
+
+    errors.add :station_id, '最後の到着以外は削除できません'
+    throw(:abort)
   end
 end

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -4,7 +4,7 @@ class Arrival < ApplicationRecord
   validates :arrived_at, presence: true
   validate :prohibit_arrival_without_next_station, if: -> { validation_context == :create }
   before_validation :convert_blank_to_nil
-  before_destroy :check_arrival_location
+  before_destroy :check_arrival_location, unless: -> { destroyed_by_association }
 
   private
 
@@ -27,6 +27,7 @@ class Arrival < ApplicationRecord
   end
 
   def check_arrival_location
+    return if destroyed_by_association
     return if self == walk.arrivals.order(:arrived_at).last
 
     errors.add :station_id, '最後の到着以外は削除できません'

--- a/app/models/walk.rb
+++ b/app/models/walk.rb
@@ -32,8 +32,6 @@ class Walk < ApplicationRecord
     arrivals_without_departure.length
   end
 
-  private
-
   def departure_station
     arrivals.order(:created_at).first.station
   end

--- a/app/models/walk.rb
+++ b/app/models/walk.rb
@@ -9,7 +9,7 @@ class Walk < ApplicationRecord
   end
 
   def arrived_stations
-    arrivals.includes(:station).order(arrived_at: :asc).map(&:station)
+    sorted_arrivals.map(&:station)
   end
 
   def arrivals_without_departure
@@ -17,7 +17,7 @@ class Walk < ApplicationRecord
   end
 
   def sorted_arrivals
-    arrivals.includes(:station).order(arrived_at: :asc)
+    arrivals.includes(:station).order(:id)
   end
 
   def latest_arrival

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -1,10 +1,10 @@
 = render 'shared/errors', model: arrival
-.px-8.pb-4
-  = turbo_frame_tag arrival do
+= turbo_frame_tag arrival do
+  .px-8.py-4
     p.inline.text-2xl
       | #{arrival.arrived_at.strftime('%k:%M')} #{arrival.station.name}駅 #{arrival.station == arrival.walk.departure_station ? "出発" : nil}
     - if arrival.memo
       span.text-zinc-500.text-base.ml-4 #{arrival.memo}
     = link_to  "編集", edit_arrival_path(arrival), class: "text-base text-blue-600 hover:underline ml-4"
-  - if @walk.user == current_user && arrival == @arrivals.last && arrival.station != current_walk.departure_station
-    = link_to "到着を削除", arrival, class: "text-base text-blue-600 hover:underline ml-4", data: { turbo_method: "delete", turbo_confirm: "本当に削除しますか？" }
+    - if @walk.user == current_user && arrival == @arrivals.last && arrival.station != current_walk.departure_station
+      = link_to "到着を削除", arrival, class: "text-base text-blue-600 hover:underline ml-4", data: { turbo_method: "delete", turbo_confirm: "本当に削除しますか？" }

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -4,9 +4,9 @@
       - if arrival.station == arrival.walk.departure_station
         | #{arrival.created_at.strftime('%k:%M')} #{arrival.station.name}駅 出発
       - else
-        | #{arrival.arrived_at&.strftime('%k:%M')} #{arrival.station.name}駅
+        | #{arrival.arrived_at.strftime('%k:%M')} #{arrival.station.name}駅
         = link_to  "編集", edit_arrival_path(arrival.id), class: "text-base text-blue-600 hover:underline ml-4"
-        - if @walk.user == current_user && arrival == @arrivals.last
-          = button_to '削除', arrival, method: :delete, class:"text-base text-blue-600 hover:underline ml-4", form: { data: { turbo_confirm: "本当に削除しますか？" }, class: "inline" }
     - if arrival.memo
-      p.text-zinc-500.text-base #{arrival.memo}
+      span.text-zinc-500.text-base #{arrival.memo}
+  - if @walk.user == current_user && arrival == @arrivals.last && arrival.station != current_walk.departure_station
+    = link_to "削除", arrival, class: "text-base text-blue-600 hover:underline ml-4", data: { turbo_method: "delete", turbo_confirm: "本当に削除しますか？" }

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -7,4 +7,4 @@
       span.text-zinc-500.text-base.ml-4 #{arrival.memo}
     = link_to  "編集", edit_arrival_path(arrival), class: "text-base text-blue-600 hover:underline ml-4"
     - if @walk.user == current_user && arrival == @arrivals.last && arrival.station != current_walk.departure_station
-      = link_to "到着を削除", arrival, class: "text-base text-blue-600 hover:underline ml-4", data: { turbo_method: "delete", turbo_confirm: "本当に削除しますか？" }
+      = link_to "到着を削除", arrival, class: "text-base text-blue-600 hover:underline ml-4", data: { turbo_frame: "_top", turbo_method: "delete", turbo_confirm: "本当に削除しますか？" }

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -2,9 +2,9 @@
 = turbo_frame_tag arrival do
   .px-8.py-4
     p.inline.text-2xl
-      | #{arrival.arrived_at.strftime('%k:%M')} #{arrival.station.name}駅 #{arrival.station == arrival.walk.departure_station ? "出発" : nil}
+      | #{arrival.arrived_at.strftime('%k:%M')} #{arrival.station.name}駅 #{arrival.station == arrival.walk.departure_station ? '出発' : nil}
     - if arrival.memo
       span.text-zinc-500.text-base.ml-4 #{arrival.memo}
-    = link_to  "編集", edit_arrival_path(arrival), class: "text-base text-blue-600 hover:underline ml-4"
+    = link_to '編集', edit_arrival_path(arrival), class: 'text-base text-blue-600 hover:underline ml-4'
     - if @walk.user == current_user && arrival == @arrivals.last && arrival.station != current_walk.departure_station
-      = link_to "到着を削除", arrival, class: "text-base text-blue-600 hover:underline ml-4", data: { turbo_frame: "_top", turbo_method: "delete", turbo_confirm: "本当に削除しますか？" }
+      = link_to '到着を削除', arrival, class: 'text-base text-blue-600 hover:underline ml-4', data: { turbo_frame: '_top', turbo_method: 'delete', turbo_confirm: '本当に削除しますか？' }

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -1,0 +1,12 @@
+.px-8.pb-4
+  = turbo_frame_tag arrival do
+    p.inline.text-2xl
+      - if arrival.station == arrival.walk.departure_station
+        | #{arrival.created_at.strftime('%k:%M')} #{arrival.station.name}駅 出発
+      - else
+        | #{arrival.arrived_at&.strftime('%k:%M')} #{arrival.station.name}駅
+        = link_to  "編集", edit_arrival_path(arrival.id), class: "text-base text-blue-600 hover:underline ml-4"
+        - if @walk.user == current_user && arrival == @arrivals.last
+          = button_to '削除', arrival, method: :delete, class:"text-base text-blue-600 hover:underline ml-4", form: { data: { turbo_confirm: "本当に削除しますか？" }, class: "inline" }
+    - if arrival.memo
+      p.text-zinc-500.text-base #{arrival.memo}

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -1,12 +1,10 @@
+= render 'shared/errors', model: arrival
 .px-8.pb-4
   = turbo_frame_tag arrival do
     p.inline.text-2xl
-      - if arrival.station == arrival.walk.departure_station
-        | #{arrival.created_at.strftime('%k:%M')} #{arrival.station.name}駅 出発
-      - else
-        | #{arrival.arrived_at.strftime('%k:%M')} #{arrival.station.name}駅
-        = link_to  "編集", edit_arrival_path(arrival.id), class: "text-base text-blue-600 hover:underline ml-4"
+      | #{arrival.arrived_at.strftime('%k:%M')} #{arrival.station.name}駅 #{arrival.station == arrival.walk.departure_station ? "出発" : nil}
     - if arrival.memo
-      span.text-zinc-500.text-base #{arrival.memo}
+      span.text-zinc-500.text-base.ml-4 #{arrival.memo}
+    = link_to  "編集", edit_arrival_path(arrival), class: "text-base text-blue-600 hover:underline ml-4"
   - if @walk.user == current_user && arrival == @arrivals.last && arrival.station != current_walk.departure_station
-    = link_to "削除", arrival, class: "text-base text-blue-600 hover:underline ml-4", data: { turbo_method: "delete", turbo_confirm: "本当に削除しますか？" }
+    = link_to "到着を削除", arrival, class: "text-base text-blue-600 hover:underline ml-4", data: { turbo_method: "delete", turbo_confirm: "本当に削除しますか？" }

--- a/app/views/arrivals/_edit.html.slim
+++ b/app/views/arrivals/_edit.html.slim
@@ -1,0 +1,5 @@
+= arrival.arrived_at
+= form_with model: arrival, method: :put do |form|
+  = form.datetime_field :arrived_at, value: arrival.arrived_at.strftime('%FT%R')
+  = form.text_field :memo
+  = form.submit "保存"

--- a/app/views/arrivals/_edit.html.slim
+++ b/app/views/arrivals/_edit.html.slim
@@ -1,5 +1,0 @@
-= arrival.arrived_at
-= form_with model: arrival, method: :put do |form|
-  = form.datetime_field :arrived_at, value: arrival.arrived_at.strftime('%FT%R')
-  = form.text_field :memo
-  = form.submit "保存"

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -1,9 +1,9 @@
 = turbo_frame_tag @arrival
   .px-8.py-4
     = render 'shared/errors', model: @arrival
-    = form_with model: @arrival, method: :put, class: "inline" do |f|
+    = form_with model: @arrival, method: :put, class: 'inline' do |f|
       = f.time_select :arrived_at, value: @arrival.arrived_at
-      p.inline.text-2xl.ml-4.mr-4 #{(@arrival.station.name + "駅").ljust(4, "　")}
-      = f.label :memo, "メモ："
-      = f.text_field :memo, class:"mr-2"
-      = f.submit "保存", class:"btn-primary"
+      p.inline.text-2xl.ml-4.mr-4 #{@arrival.station.name}駅
+      = f.label :memo, 'メモ：'
+      = f.text_field :memo, class: 'mr-2'
+      = f.submit '保存', class: 'btn-primary'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -1,1 +1,0 @@
-= render 'shared/memo'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -1,8 +1,9 @@
 = turbo_frame_tag @arrival
-  = form_with model: @arrival, method: :put, class: "inline" do |f|
-    = render 'shared/errors', model: f.object
-    = f.time_select :arrived_at, value: @arrival.arrived_at
-    p.inline.text-2xl.mr-8 #{@arrival.station.name}駅
-    = f.label :memo, "メモ："
-    = f.text_field :memo
-    = f.submit "保存"
+  .px-8.py-4
+    = render 'shared/errors', model: @arrival
+    = form_with model: @arrival, method: :put, class: "inline" do |f|
+      = f.time_select :arrived_at, value: @arrival.arrived_at
+      p.inline.text-2xl.ml-4.mr-4 #{(@arrival.station.name + "駅").ljust(4, "　")}
+      = f.label :memo, "メモ："
+      = f.text_field :memo, class:"mr-2"
+      = f.submit "保存", class:"btn-primary"

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -1,0 +1,8 @@
+= turbo_frame_tag @arrival
+  = form_with model: @arrival, method: :put do |f|
+    = f.time_select :arrived_at, value: @arrival.arrived_at
+    p.inline.text-2xl #{@arrival.station.name}駅
+    br
+    - if @arrival.memo
+      = f.text_field :memo
+    = f.submit "保存"

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -3,6 +3,6 @@
     = f.time_select :arrived_at, value: @arrival.arrived_at
     p.inline.text-2xl #{@arrival.station.name}駅
     br
-    - if @arrival.memo
-      = f.text_field :memo
+    = f.label :memo
+    = f.text_field :memo
     = f.submit "保存"

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -1,8 +1,8 @@
 = turbo_frame_tag @arrival
-  = form_with model: @arrival, method: :put do |f|
+  = form_with model: @arrival, method: :put, class: "inline" do |f|
+    = render 'shared/errors', model: f.object
     = f.time_select :arrived_at, value: @arrival.arrived_at
-    p.inline.text-2xl #{@arrival.station.name}駅
-    br
-    = f.label :memo
+    p.inline.text-2xl.mr-8 #{@arrival.station.name}駅
+    = f.label :memo, "メモ："
     = f.text_field :memo
     = f.submit "保存"

--- a/app/views/arrivals/index.html.slim
+++ b/app/views/arrivals/index.html.slim
@@ -10,14 +10,15 @@ h2.text-2xl.font-bold.mt-4 到着履歴
           span #{@walk.publish ? '公開' : '非公開'}
 
 - @arrivals.each_with_index do |arrival, i|
-  .text-2xl.px-8.pb-4
-    p.inline
+  .px-8.pb-4
+    p.inline.text-2xl
       - if i.zero?
         | #{arrival.created_at.strftime('%k:%M')} #{arrival.station.name}駅 出発
       - else
         | #{arrival.arrived_at&.strftime('%k:%M')} #{arrival.station.name}駅
+        = render partial: 'edit', locals: { arrival: arrival }
         - if @walk.user == current_user && arrival == @arrivals.last
-            = button_to '削除', arrival, method: :delete, class:"text-base text-blue-600 hover:underline ml-4", form: { class: "inline" }
+          = button_to '削除', arrival, method: :delete, class:"text-base text-blue-600 hover:underline ml-4", form: { class: "inline" }
     - if arrival.memo
       p.text-zinc-500.text-base #{arrival.memo}
 

--- a/app/views/arrivals/index.html.slim
+++ b/app/views/arrivals/index.html.slim
@@ -9,7 +9,7 @@ h2.text-2xl.font-bold.mt-4 到着履歴
           .toggle-switch.m-2
           span #{@walk.publish ? '公開' : '非公開'}
 
-= render partial: "arrivals/arrival", collection: @arrivals
+= render @arrivals
 
 .flex.justify-end
   = link_to '> 地図に戻る', walk_path, class: 'dark:text-gray-500 hover:underline inline-block'

--- a/app/views/arrivals/index.html.slim
+++ b/app/views/arrivals/index.html.slim
@@ -11,16 +11,17 @@ h2.text-2xl.font-bold.mt-4 到着履歴
 
 - @arrivals.each_with_index do |arrival, i|
   .px-8.pb-4
-    p.inline.text-2xl
-      - if i.zero?
-        | #{arrival.created_at.strftime('%k:%M')} #{arrival.station.name}駅 出発
-      - else
-        | #{arrival.arrived_at&.strftime('%k:%M')} #{arrival.station.name}駅
-        = render partial: 'edit', locals: { arrival: arrival }
-        - if @walk.user == current_user && arrival == @arrivals.last
-          = button_to '削除', arrival, method: :delete, class:"text-base text-blue-600 hover:underline ml-4", form: { class: "inline" }
-    - if arrival.memo
-      p.text-zinc-500.text-base #{arrival.memo}
+    = turbo_frame_tag arrival
+      p.inline.text-2xl
+        - if i.zero?
+          | #{arrival.created_at.strftime('%k:%M')} #{arrival.station.name}駅 出発
+        - else
+          | #{arrival.arrived_at&.strftime('%k:%M')} #{arrival.station.name}駅
+          = link_to  "編集", edit_arrival_path(arrival.id), class: "text-base text-blue-600 hover:underline ml-4"
+          - if @walk.user == current_user && arrival == @arrivals.last
+            = button_to '削除', arrival, method: :delete, class:"text-base text-blue-600 hover:underline ml-4", form: { class: "inline" }
+      - if arrival.memo
+        p.text-zinc-500.text-base #{arrival.memo}
 
 .flex.justify-end
   = link_to '> 地図に戻る', walk_path, class: 'dark:text-gray-500 hover:underline inline-block'

--- a/app/views/arrivals/index.html.slim
+++ b/app/views/arrivals/index.html.slim
@@ -9,19 +9,7 @@ h2.text-2xl.font-bold.mt-4 到着履歴
           .toggle-switch.m-2
           span #{@walk.publish ? '公開' : '非公開'}
 
-- @arrivals.each_with_index do |arrival, i|
-  .px-8.pb-4
-    = turbo_frame_tag arrival
-      p.inline.text-2xl
-        - if i.zero?
-          | #{arrival.created_at.strftime('%k:%M')} #{arrival.station.name}駅 出発
-        - else
-          | #{arrival.arrived_at&.strftime('%k:%M')} #{arrival.station.name}駅
-          = link_to  "編集", edit_arrival_path(arrival.id), class: "text-base text-blue-600 hover:underline ml-4"
-          - if @walk.user == current_user && arrival == @arrivals.last
-            = button_to '削除', arrival, method: :delete, class:"text-base text-blue-600 hover:underline ml-4", form: { class: "inline" }
-      - if arrival.memo
-        p.text-zinc-500.text-base #{arrival.memo}
+= render partial: "arrivals/arrival", collection: @arrivals
 
 .flex.justify-end
   = link_to '> 地図に戻る', walk_path, class: 'dark:text-gray-500 hover:underline inline-block'

--- a/app/views/arrivals/index.html.slim
+++ b/app/views/arrivals/index.html.slim
@@ -10,12 +10,14 @@ h2.text-2xl.font-bold.mt-4 到着履歴
           span #{@walk.publish ? '公開' : '非公開'}
 
 - @arrivals.each_with_index do |arrival, i|
-  .arrival-container.text-2xl.px-8.pb-4
-    p.text-2xl
+  .text-2xl.px-8.pb-4
+    p.inline
       - if i.zero?
         | #{arrival.created_at.strftime('%k:%M')} #{arrival.station.name}駅 出発
       - else
         | #{arrival.arrived_at&.strftime('%k:%M')} #{arrival.station.name}駅
+        - if @walk.user == current_user && arrival == @arrivals.last
+            = button_to '削除', arrival, method: :delete, class:"text-base text-blue-600 hover:underline ml-4", form: { class: "inline" }
     - if arrival.memo
       p.text-zinc-500.text-base #{arrival.memo}
 

--- a/app/views/arrivals/update.turbo_stream.slim
+++ b/app/views/arrivals/update.turbo_stream.slim
@@ -1,1 +1,2 @@
 = turbo_stream.replace @arrival
+= turbo_stream.update "flash", partial: "layouts/flash"

--- a/app/views/arrivals/update.turbo_stream.slim
+++ b/app/views/arrivals/update.turbo_stream.slim
@@ -1,2 +1,2 @@
 = turbo_stream.replace @arrival
-= turbo_stream.update "flash", partial: "layouts/flash"
+= turbo_stream.update 'flash', partial: 'layouts/flash'

--- a/app/views/arrivals/update.turbo_stream.slim
+++ b/app/views/arrivals/update.turbo_stream.slim
@@ -1,0 +1,1 @@
+= turbo_stream.replace @arrival

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -21,5 +21,6 @@ html
       h1.text-3xl.font-bold.p-2
         | YamaNotes
       .items.px-8.py-2
-        = render 'layouts/flash'
+        #flash
+          = render 'layouts/flash'
         = yield

--- a/app/views/shared/_memo.html.slim
+++ b/app/views/shared/_memo.html.slim
@@ -1,7 +1,7 @@
-dialog data-modal-target="dialog" data-action="click->modal#backdropClose" class="p-4 rounded-lg backdrop:bg-black/80"
+dialog data-modal-target="dialog" class="p-4 rounded-lg backdrop:bg-black/80"
   span #{arrival.station.name}駅のメモを追加
   button data-action="click->modal#close" class="float-right"
     i class="fa-regular fa-rectangle-xmark"
   = form_with model: arrival do |form|
     = form.text_area :memo, rows: '4', class: 'w-80'
-    = form.submit '保存', class: 'block btn-primary mx-auto'
+    = form.submit '保存', class: 'block btn-primary mx-auto', data: {action: "click->modal#close"}

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,7 @@ module Yamanotes
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
     #
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  namespace :users do
-    get 'arrivals/index'
-  end
   resource :walk, except: [:index]
   resources :arrivals, except: [:new]
-  get '/stations', to: 'stations#index', defaults: { format: 'json' }
   get '/users/:id/arrivals', to: 'users/arrivals#index', :as => :public_arrivals
-  devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
 
+  devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
   devise_scope :user do
     get 'logout', :to => 'devise/sessions#destroy', :as => :destroy_user_session
   end

--- a/db/migrate/20240323055616_create_arrivals.rb
+++ b/db/migrate/20240323055616_create_arrivals.rb
@@ -4,7 +4,7 @@ class CreateArrivals < ActiveRecord::Migration[7.1]
       t.belongs_to :walk, foreign_key: true
       t.belongs_to :station, foreign_key: true
       t.string :memo
-      t.timestamp :arrived_at, precision: 6, null: false
+      t.timestamp :arrived_at, precision: 0, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_23_055616) do
     t.bigint "walk_id"
     t.bigint "station_id"
     t.string "memo"
-    t.datetime "arrived_at", null: false
+    t.datetime "arrived_at", precision: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["station_id"], name: "index_arrivals_on_station_id"

--- a/spec/system/arrivals_spec.rb
+++ b/spec/system/arrivals_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Arrivals', type: :system, js: true do
     fill_in 'arrival_memo', with: 'もうすぐつきそう'
     click_on '保存'
     expect(page).to have_content('到着記録を更新しました')
-    click_on 'memo_modal_button'
+    visit arrivals_path
     expect(page).to have_content('もうすぐつきそう')
   end
 
@@ -77,7 +77,7 @@ RSpec.describe 'Arrivals', type: :system, js: true do
     fill_in 'arrival_memo', with: 'まだまだつかない'
     click_on '保存'
     expect(page).to have_content('到着記録を更新しました')
-    click_on 'memo_modal_button'
+    visit arrivals_path
     expect(page).to have_content('まだまだつかない')
     expect(page).to_not have_content('もうすぐつきそう')
   end


### PR DESCRIPTION
到着一覧ページで、到着時間・メモの更新及び、到着履歴削除が行えるようにしました。

## 編集機能
- https://github.com/SuzukaHori/YamaNotes/issues/62

[![Image from Gyazo](https://i.gyazo.com/e43d63cbdc915ccb6baea3292f7c8031.gif)](https://gyazo.com/e43d63cbdc915ccb6baea3292f7c8031)

## 削除機能
- https://github.com/SuzukaHori/YamaNotes/issues/63
[![Image from Gyazo](https://i.gyazo.com/6fa4407e0f37d0882ff60619e6e249e2.gif)](https://gyazo.com/6fa4407e0f37d0882ff60619e6e249e2)

バリデーションにより、以下の動作を禁止しました。
- 現在時刻より前の到着時刻の設定。
- 前後の到着時刻と齟齬のある到着時刻の設定。

テストの追加は別のIssueで取り組むため行なっていません。