### PR TITLE
到着履歴編集・削除機能のテストを作成

### DIFF
--- a/spec/models/arrival_spec.rb
+++ b/spec/models/arrival_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Arrival, type: :model do
 
   describe '近接する駅以外への到着を禁止する' do
     it '近接する駅に到着する' do
-      expect do
-        @walk.arrivals.create!(station_id: 2, arrived_at: Time.current)
-      end.to change { Arrival.count }.by(1)
+      expect { create_second_arrival }.to change { Arrival.count }.by(1)
     end
 
     it '近接しない駅には到着できない' do
@@ -18,5 +16,47 @@ RSpec.describe Arrival, type: :model do
         @walk.arrivals.create!(station_id: 13, arrived_at: Time.current)
       end.to raise_error(ActiveRecord::RecordInvalid)
     end
+  end
+
+  describe '#check_arrived_time' do
+    it '到着時刻を更新できる' do
+      expect(@arrival.update(arrived_at: @arrival.arrived_at - 60)).to be true
+    end
+
+    it '未来の時刻を到着時刻に設定できない' do
+      arrival = create_second_arrival
+      arrival.arrived_at += 60
+      expect(arrival.valid?).to be false
+    end
+
+    it '一つ前の到着時刻より前の時刻を設定できない' do
+      arrival = @walk.arrivals.create!(station_id: 2, arrived_at: @arrival.arrived_at)
+      arrival.arrived_at = @arrival.arrived_at - 60
+      expect(arrival.valid?).to be false
+    end
+
+    it '一つ後ろの到着時刻より後の時刻を設定できない' do
+      arrival = create_second_arrival
+      @arrival.arrived_at = arrival.arrived_at + 60
+      expect(@arrival.valid?).to be false
+    end
+  end
+
+  describe '#check_arrival_location' do
+    it '最後の到着を削除できる' do
+      arrival = create_second_arrival
+      expect { arrival.destroy! }.to change { Arrival.count }.by(-1)
+    end
+
+    it '最後の到着以外を削除できない' do
+      create_second_arrival
+      expect { @arrival.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
+    end
+  end
+
+  private
+
+  def create_second_arrival
+    @walk.arrivals.create!(station_id: 2, arrived_at: Time.current)
   end
 end

--- a/spec/system/arrivals_spec.rb
+++ b/spec/system/arrivals_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe 'Arrivals', type: :system, js: true do
     visit arrivals_path
     click_on '編集'
     time = Time.current + 60
-    select format("%02d",time.hour), from: 'arrival_arrived_at_4i'
-    select format("%02d",time.min), from: 'arrival_arrived_at_5i'
+    select format('%02d', time.hour), from: 'arrival_arrived_at_4i'
+    select format('%02d', time.min), from: 'arrival_arrived_at_5i'
     click_on '保存'
     expect(page).to have_content('到着時刻に未来の時刻は設定できません')
   end

--- a/spec/system/arrivals_spec.rb
+++ b/spec/system/arrivals_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe 'Arrivals', type: :system, js: true do
     expect(page).to have_content('到着時刻に未来の時刻は設定できません')
   end
 
+  scenario '到着記録を削除する' do
+    start_walk
+    click_on '到着'
+    click_on '地図に戻る'
+    expect(page).to have_content('現在の駅 ：大崎駅')
+    visit arrivals_path
+    expect(page).to have_content('大崎駅')
+    page.accept_confirm do
+      click_on '到着を削除'
+    end
+    expect(page).to_not have_content('大崎駅')
+  end
+
   def start_walk
     visit new_walk_path
     click_on 'はじめる'

--- a/spec/system/arrivals_spec.rb
+++ b/spec/system/arrivals_spec.rb
@@ -58,41 +58,6 @@ RSpec.describe 'Arrivals', type: :system, js: true do
     expect(page).to have_content('現在の駅 ：渋谷駅')
   end
 
-  scenario 'メモを追加できる' do
-    start_walk
-    click_on 'memo_modal_button'
-    fill_in 'arrival_memo', with: 'もうすぐつきそう'
-    click_on '保存'
-    expect(page).to have_content('到着記録を更新しました')
-    visit arrivals_path
-    expect(page).to have_content('もうすぐつきそう')
-  end
-
-  scenario 'メモを編集できる' do
-    start_walk
-    click_on 'memo_modal_button'
-    fill_in 'arrival_memo', with: 'もうすぐつきそう'
-    click_on '保存'
-    click_on 'memo_modal_button'
-    fill_in 'arrival_memo', with: 'まだまだつかない'
-    click_on '保存'
-    expect(page).to have_content('到着記録を更新しました')
-    visit arrivals_path
-    expect(page).to have_content('まだまだつかない')
-    expect(page).to_not have_content('もうすぐつきそう')
-  end
-
-  # scenario 'メモを削除' do
-  #   start_walk
-  #   click_on 'memo_modal_button'
-  #   fill_in 'arrival_memo', with: 'もうすぐつきそう'
-  #   click_on '保存'
-  #   click_on 'メモを編集'
-  #   click_on 'メモを削除'
-  #   click_on 'memo_modal_button'
-  #   expect(page).to_not have_content('もうすぐつきそう')
-  # end
-
   def start_walk
     visit new_walk_path
     click_on 'はじめる'

--- a/spec/system/arrivals_spec.rb
+++ b/spec/system/arrivals_spec.rb
@@ -58,6 +58,28 @@ RSpec.describe 'Arrivals', type: :system, js: true do
     expect(page).to have_content('現在の駅 ：渋谷駅')
   end
 
+  scenario '到着時刻を編集する' do
+    start_walk
+    expect(page).to have_content('現在の駅 ：品川駅')
+    visit arrivals_path
+    click_on '編集'
+    select '00', from: 'arrival_arrived_at_4i'
+    select '00', from: 'arrival_arrived_at_5i'
+    click_on '保存'
+    expect(page).to have_content('到着記録を更新しました')
+  end
+
+  scenario '不正な到着時刻に編集する' do
+    start_walk
+    visit arrivals_path
+    click_on '編集'
+    time = Time.current + 60
+    select format("%02d",time.hour), from: 'arrival_arrived_at_4i'
+    select format("%02d",time.min), from: 'arrival_arrived_at_5i'
+    click_on '保存'
+    expect(page).to have_content('到着時刻に未来の時刻は設定できません')
+  end
+
   def start_walk
     visit new_walk_path
     click_on 'はじめる'

--- a/spec/system/memos_spec.rb
+++ b/spec/system/memos_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe 'Memos', type: :system, js: true do
+  before do
+    user = FactoryBot.create(:user)
+    sign_in user
+  end
+
+  context 'トップページでメモを操作する' do
+    scenario 'メモを追加する' do
+      start_walk
+      click_on 'memo_modal_button'
+      fill_in 'arrival_memo', with: 'もうすぐつきそう'
+      click_on '保存'
+      expect(page).to have_content('到着記録を更新しました')
+      visit arrivals_path
+      expect(page).to have_content('もうすぐつきそう')
+    end
+
+    scenario 'メモを編集する' do
+      start_walk
+      click_on 'memo_modal_button'
+      fill_in 'arrival_memo', with: 'もうすぐつきそう'
+      click_on '保存'
+      click_on 'memo_modal_button'
+      fill_in 'arrival_memo', with: 'まだまだつかない'
+      click_on '保存'
+      expect(page).to have_content('到着記録を更新しました')
+      visit arrivals_path
+      expect(page).to have_content('まだまだつかない')
+      expect(page).to_not have_content('もうすぐつきそう')
+    end
+  end
+
+  context '到着一覧ページで操作する' do
+    scenario 'メモを追加する' do
+      start_walk
+      visit arrivals_path
+      click_on '編集'
+      fill_in 'メモ', with: 'もうすぐつきそう'
+      click_on '保存'
+      expect(page).to have_content('到着記録を更新しました')
+    end
+
+    scenario 'メモを編集する' do
+      start_walk
+      visit arrivals_path
+      click_on '編集'
+      fill_in 'メモ', with: 'もうすぐつきそう'
+      click_on '保存'
+      click_on '編集'
+      fill_in 'メモ', with: 'まだまだつかない'
+      click_on '保存'
+      expect(page).to have_content('まだまだつかない')
+      expect(page).to_not have_content('もうすぐつきそう')
+    end
+  end
+
+  def start_walk
+    visit new_walk_path
+    click_on 'はじめる'
+  end
+end


### PR DESCRIPTION
履歴一覧画面が正常に動作するかどうか（表示・編集・削除）の最低限のテストを作成しました。

- https://github.com/SuzukaHori/YamaNotes/issues/78
- https://github.com/SuzukaHori/YamaNotes/issues/77