### PR TITLE
履歴公開ページにアクセスできないバグを修正

### DIFF
--- a/app/controllers/users/arrivals_controller.rb
+++ b/app/controllers/users/arrivals_controller.rb
@@ -4,7 +4,7 @@ class Users::ArrivalsController < ApplicationController
     walk = user.walk
     if walk.publish || current_user == user
       @walk = user.walk
-      @arrivals = @walk.arrivals.includes(:station)
+      @arrivals = @walk.sorted_arrivals
       render 'arrivals/index'
     else
       redirect_to root_path, notice: 'この到着記録は非公開です'

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -5,6 +5,8 @@
       | #{arrival.arrived_at.strftime('%k:%M')} #{arrival.station.name}駅 #{arrival.station == arrival.walk.departure_station ? '出発' : nil}
     - if arrival.memo
       span.text-zinc-500.text-base.ml-4 #{arrival.memo}
-    = link_to '編集', edit_arrival_path(arrival), class: 'text-base text-blue-600 hover:underline ml-4'
-    - if @walk.user == current_user && arrival == @arrivals.last && arrival.station != current_walk.departure_station
-      = link_to '到着を削除', arrival, class: 'text-base text-blue-600 hover:underline ml-4', data: { turbo_frame: '_top', turbo_method: 'delete', turbo_confirm: '本当に削除しますか？' }
+
+    - if arrival.walk.user == current_user
+      = link_to '編集', edit_arrival_path(arrival), class: 'text-base text-blue-600 hover:underline ml-4'
+      - if @walk.user == current_user && arrival == @arrivals.last && arrival.station != current_walk.departure_station
+        = link_to '到着を削除', arrival, class: 'text-base text-blue-600 hover:underline ml-4', data: { turbo_frame: '_top', turbo_method: 'delete', turbo_confirm: '本当に削除しますか？' }

--- a/app/views/arrivals/index.html.slim
+++ b/app/views/arrivals/index.html.slim
@@ -8,8 +8,7 @@ h2.text-2xl.font-bold.mt-4 到着履歴
           = f.check_box :publish, { class: 'sr-only peer', onchange: 'this.form.requestSubmit()' }, 'true', 'false'
           .toggle-switch.m-2
           span #{@walk.publish ? '公開' : '非公開'}
-
-= render @arrivals
+= render partial: 'arrivals/arrival', collection: @arrivals, as: :arrival
 
 .flex.justify-end
   = link_to '> 地図に戻る', walk_path, class: 'dark:text-gray-500 hover:underline inline-block'

--- a/app/views/shared/_memo.html.slim
+++ b/app/views/shared/_memo.html.slim
@@ -4,4 +4,4 @@ dialog data-modal-target="dialog" class="p-4 rounded-lg backdrop:bg-black/80"
     i class="fa-regular fa-rectangle-xmark"
   = form_with model: arrival do |form|
     = form.text_area :memo, rows: '4', class: 'w-80'
-    = form.submit '保存', class: 'block btn-primary mx-auto', data: {action: "click->modal#close"}
+    = form.submit '保存', class: 'block btn-primary mx-auto', data: { action: 'click->modal#close' }

--- a/spec/system/users_arrivals_spec.rb
+++ b/spec/system/users_arrivals_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Users/Arrivals', type: :system do
   scenario '公開状態の到着履歴にアクセスする' do
     visit public_arrivals_path(@user)
     expect(page).to have_content('品川駅')
+    expect(page).to_not have_content('編集')
   end
 
   scenario '未公開状態の到着履歴にアクセスする' do
@@ -27,5 +28,6 @@ RSpec.describe 'Users/Arrivals', type: :system do
     sign_in @user
     visit public_arrivals_path(@user)
     expect(page).to have_content('品川駅')
+    expect(page).to have_content('編集')
   end
 end


### PR DESCRIPTION
履歴編集機能の実装により、公開ページが表示できなくなっていたため修正しました。
加えて、テストファイル名の誤りにより、`bundle exec rspec`でテストが実行されていなかったため修正しました。