### PR TITLE
公開用URLをコピーボタンを実装

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static values = {
+    content: String,
+  };
+
+  connect() {
+    this.originalContent = this.element.innerHTML;
+  }
+
+  copy() {
+    navigator.clipboard.writeText(this.contentValue).then(
+      () => {
+        this.element.innerHTML =
+          "<p class='text-xs font-semibold text-green-700'>Copied!</p>";
+        setTimeout(() => {
+          this.element.innerHTML = this.originalContent;
+        }, 2000);
+      },
+      () => {
+        alert("クリップボードにコピー出来ませんでした。");
+      },
+    );
+  }
+}

--- a/app/views/arrivals/index.html.slim
+++ b/app/views/arrivals/index.html.slim
@@ -12,7 +12,7 @@ h2.text-2xl.font-bold.mt-4 到着履歴
     .div.flex.justify-end
       label.my-auto.mx-2 for='url' 公開用URL:
       = text_field_tag 'url', public_arrivals_url(@walk.user), { readonly: true, class: 'border border-gray-300 text-gray-900 rounded-lg w-1/2 p-2.5 text-sm' }
-      = button_tag data: { controller: 'clipboard', action: 'clipboard#copy', clipboard_content_value: public_arrivals_url(@walk.user) }, class: 'hover:bg-gray-100 p-2'
+      = button_tag data: { controller: 'clipboard', action: 'clipboard#copy', clipboard_content_value: public_arrivals_url(@walk.user) }, class: 'hover:bg-gray-100 p-2', id: "copy_button"
         i class='fa-regular fa-copy fa-lg'
 
 = render partial: 'arrivals/arrival', collection: @arrivals, as: :arrival

--- a/app/views/arrivals/index.html.slim
+++ b/app/views/arrivals/index.html.slim
@@ -8,8 +8,15 @@ h2.text-2xl.font-bold.mt-4 到着履歴
           = f.check_box :publish, { class: 'sr-only peer', onchange: 'this.form.requestSubmit()' }, 'true', 'false'
           .toggle-switch.m-2
           span #{@walk.publish ? '公開' : '非公開'}
+  - if @walk.publish
+    .div.flex.justify-end
+      label.my-auto.mx-2 for='url' 公開用URL:
+      = text_field_tag 'url', public_arrivals_url(@walk.user), { readonly: true, class: 'border border-gray-300 text-gray-900 rounded-lg w-1/2 p-2.5 text-sm' }
+      = button_tag data: { controller: 'clipboard', action: 'clipboard#copy', clipboard_content_value: public_arrivals_url(@walk.user) }, class: 'hover:bg-gray-100 p-2'
+        i class='fa-regular fa-copy fa-lg'
 
 = render partial: 'arrivals/arrival', collection: @arrivals, as: :arrival
 
-.flex.justify-end
-  = link_to '> 地図に戻る', walk_path, class: 'dark:text-gray-500 hover:underline inline-block'
+- if @walk.user == current_user
+  .flex.justify-end
+    = link_to '> 地図に戻る', walk_path, class: 'dark:text-gray-500 hover:underline inline-block'

--- a/spec/system/users_arrivals_spec.rb
+++ b/spec/system/users_arrivals_spec.rb
@@ -11,12 +11,22 @@ RSpec.describe 'Users/Arrivals', type: :system do
       setting_and_visit_public_path(walk_public)
       expect(page).to have_content('編集')
     end
+
+    it '公開用URLをコピーする' do
+      sign_in user
+      setting_and_visit_public_path(walk_public)
+      url = find_field('公開用URL:').value
+      expect(url).to include(public_arrivals_path(user))
+      click_on 'copy_button'
+      expect(page).to have_content('Copied')
+    end
   end
 
   context '未ログインでアクセスした場合' do
     it '公開状態の到着履歴にアクセスする' do
       setting_and_visit_public_path(walk_public)
       expect(page).to_not have_content('編集')
+      expect(page).to_not have_content('公開用URL:')
     end
 
     it '未公開状態の到着履歴にアクセスできない' do


### PR DESCRIPTION
到着履歴が公開状態の場合、URLをコピーするボタンが表示されるようにしました。

- https://github.com/SuzukaHori/YamaNotes/issues/99
[![Image from Gyazo](https://i.gyazo.com/c907d8598433d80fd417a4101dba7c67.gif)](https://gyazo.com/c907d8598433d80fd417a4101dba7c67)