### PR TITLE
到着ページのOGPが表示されないバグを修正

### DIFF
--- a/app/controllers/arrivals/report_controller.rb
+++ b/app/controllers/arrivals/report_controller.rb
@@ -1,0 +1,7 @@
+class Arrivals::ReportController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def show
+    @arrival = Arrival.find(params[:arrival_id])
+  end
+end

--- a/app/views/arrivals/report/show.html.slim
+++ b/app/views/arrivals/report/show.html.slim
@@ -1,0 +1,7 @@
+ruby: 
+  title #{@arrival.station.name}駅に到着
+  image = image_url('arrived.png')
+  set_meta_tags({ og: { image: }, twitter: { card: 'summary', image: } })
+.text-center
+  p.text-xl.font-bold.mt-4 #{@arrival.station.name}駅に到着しました🎉
+  = image_tag 'arrived.png', class: 'inline p-2', size: '160x160', alt: '山手線徒歩で一周に挑戦中'

--- a/app/views/arrivals/show.html.slim
+++ b/app/views/arrivals/show.html.slim
@@ -1,7 +1,5 @@
 ruby:
   title "#{@station.name}駅に到着"
-  image = image_url('arrived.png')
-  set_meta_tags({ og: { image: }, twitter: { card: 'summary', image: } })
   if @walk.finished?
     time = time_to_reach_goal(@walk)
     text_for_post = "【山手線を徒歩で一周に挑戦中】%0a山手線#{Station.count}駅全てを歩ききりました🎉🎉かかった時間は#{time}でした！"
@@ -21,7 +19,7 @@ ruby:
       | 歩いた駅は#{number_of_walked}駅（残り#{number_of_remaining}駅）、
       | 歩いた距離は約#{total_distance}kmです！
   .my-6
-    = render partial: 'shared/post', locals: { text: text_for_post }
+    = render partial: 'shared/post', locals: { text: text_for_post, url: arrival_report_url(@arrival) }
     div data-controller='modal' class='inline-block ml-4'
       button data-action='modal#open' id='memo_modal_button'
         | メモを開く

--- a/app/views/shared/_post.html.slim
+++ b/app/views/shared/_post.html.slim
@@ -1,4 +1,4 @@
-= link_to "https://twitter.com/intent/tweet?text=#{text}&url=#{root_url}&hashtags=山手線を徒歩で一周",
+= link_to "https://twitter.com/intent/tweet?text=#{text}&url=#{url}&hashtags=山手線を徒歩で一周",
   target: '_blank', rel: 'noopener', id: 'post_button',
   class: 'bg-zinc-950 hover:bg-zinc-400 py-2 px-4 text-white rounded-full' do
     i class="fa-brands fa-x-twitter pr-1"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@
 
 Rails.application.routes.draw do
   resource :walk, except: [:index]
-  resources :arrivals, except: [:new]
+  resources :arrivals, except: [:new] do
+    resource :report, only: %i(show), controller: "arrivals/report"
+  end
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
   resources :users, only: [:destroy] do
     resources :arrivals, only: [:index], :to => 'users/arrivals#index'


### PR DESCRIPTION
到着ページがログイン必須のページだったため、リダイレクトされずにOGPが表示されるよう報告ページを追加しました。