### PR TITLE
Arrival#updated?を削除

### DIFF
--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -24,7 +24,7 @@ class ArrivalsController < ApplicationController
 
   def update
     @arrival.assign_attributes(arrival_params)
-    return unless @arrival.updated?
+    return unless @arrival.changed? && @arrival.changes != { 'memo' => [nil, ''] }
 
     if @arrival.save
       flash.now.notice = '到着記録を更新しました。'

--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -24,7 +24,7 @@ class ArrivalsController < ApplicationController
 
   def update
     @arrival.assign_attributes(arrival_params)
-    return unless @arrival.changed? && @arrival.changes != { 'memo' => [nil, ''] }
+    return unless @arrival.changed?
 
     if @arrival.save
       flash.now.notice = '到着記録を更新しました。'

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -3,7 +3,7 @@
 class Arrival < ApplicationRecord
   belongs_to :walk
   belongs_to :station
-  before_validation :convert_blank_to_nil, on: :update
+  before_save :convert_nil_to_blank
   validates :arrived_at, presence: true
   validates :memo, length: { maximum: 140 }
   validate :prohibit_arrival_without_next_station, on: :create
@@ -47,8 +47,8 @@ class Arrival < ApplicationRecord
     errors.add :station_id, '隣駅以外に到着することはできません'
   end
 
-  def convert_blank_to_nil
-    self.memo = nil if memo.blank?
+  def convert_nil_to_blank
+    self.memo = '' if memo.nil?
   end
 
   def check_arrival_location

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -12,10 +12,6 @@ class Arrival < ApplicationRecord
   before_save :truncate_seconds_of_arrived_time
   before_destroy :check_arrival_location, unless: -> { destroyed_by_association }
 
-  def updated?
-    changed? && changes != { 'memo' => [nil, ''] }
-  end
-
   private
 
   def check_arrived_time

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -5,7 +5,7 @@ class Arrival < ApplicationRecord
   belongs_to :station
   before_save :convert_nil_to_blank
   validates :arrived_at, presence: true
-  validates :memo, length: { maximum: 140 }
+  validates :memo, length: { maximum: 140 }, allow_blank: true
   validate :prohibit_arrival_without_next_station, on: :create
   validate :arrivals_count_must_be_within_limit, on: :create
   validate :check_arrived_time, on: :update

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -11,7 +11,7 @@
           p.bg-yamanote-green-150.text-white.px-2.py-1.mr-1.rounded-lg.text-sm ゴール
         p.text-xl
           | #{arrival.station.name}駅
-      - if arrival.memo
+      - if arrival.memo.present?
         p.text-sm.text-zinc-500.break-all.ml-1 #{arrival.memo}
     - if arrival.walk.user == current_user
       = link_to edit_arrival_path(arrival), class: 'inline-block h-11 content-center' do

--- a/db/migrate/20240323055616_create_arrivals.rb
+++ b/db/migrate/20240323055616_create_arrivals.rb
@@ -3,7 +3,7 @@ class CreateArrivals < ActiveRecord::Migration[7.1]
     create_table :arrivals do |t|
       t.belongs_to :walk, foreign_key: true
       t.belongs_to :station, foreign_key: true
-      t.string :memo, limit: 140
+      t.string :memo, limit: 140, null: false, default: ""
       t.timestamp :arrived_at, null: false
 
       t.timestamps

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,3 +56,7 @@ else
   end
   puts 'テストユーザとデータを作成しました'
 end
+
+Arrival.find_each do |arrival|
+  arrival.update!(memo: '') unless arrival.memo
+end

--- a/spec/models/arrival_spec.rb
+++ b/spec/models/arrival_spec.rb
@@ -84,16 +84,4 @@ RSpec.describe Arrival, type: :model do
       expect(over_arrival.errors.full_messages.join).to eq '駅の数以上の到着記録は作成できません'
     end
   end
-
-  describe '#updated?' do
-    it '編集済みの場合はtrueが返ること' do
-      arrival.assign_attributes({ memo: '新しいメモ' })
-      expect(arrival.updated?).to be true
-    end
-
-    it 'メモが空文字の場合はfalseが返ること' do
-      arrival.assign_attributes({ memo: '' })
-      expect(arrival.updated?).to be false
-    end
-  end
 end

--- a/spec/models/arrival_spec.rb
+++ b/spec/models/arrival_spec.rb
@@ -49,11 +49,11 @@ RSpec.describe Arrival, type: :model do
     end
   end
 
-  describe '#convert_blank_to_nil' do
+  describe '#convert_nil_to_blank' do
     it '空文字をnilに変換すること' do
-      arrival.memo = ''
+      arrival.memo = nil
       arrival.save!
-      expect(arrival.memo.nil?).to be true
+      expect(arrival.memo == '').to be true
     end
   end
 


### PR DESCRIPTION
コードレビューの指摘：https://github.com/SuzukaHori/YamaNotes/pull/150#discussion_r1623274619 へ対応するため修正しました。

Arrivalコントローラーのプライベートメソッドにすることも考えましたが、現状updateアクション以外での使用が想定されないため、メソッドにせずそのまま書く形で対応しました。