### PR TITLE
外回りと内回りの選択に関する説明文を追加

### DIFF
--- a/app/views/walks/new.html.slim
+++ b/app/views/walks/new.html.slim
@@ -4,7 +4,7 @@
 .my-10.mx-auto.py-8.px-4.border-4.text-lg.text-center.md:w-2/3
   .text-center.my-0.mx-auto
     h2.mb-2 YamaNotesへようこそ！
-    p.mb-6 一周の設定をしてください。
+    p.mb-6 一周の設定をしてください。外回り、内回りで距離に大差はありません。スケジュールに合わせて好きな方を選択しましょう。
     = form_with model: [@walk, @arrival], url: walk_path, method: :post do |f|
       .mb-6
         = f.label :station_id, '出発駅', name: 'arrival[station_id]', class: 'pr-2'


### PR DESCRIPTION
fix #196

<img width="648" alt="image" src="https://github.com/user-attachments/assets/42f0951b-2206-4fbd-8b69-fdc28e63eaa9">


- ユーザーが外回りと内回りの選択に迷わないように、距離に大差がないこととスケジュールに合わせて選択できる旨の説明文を追加しました。

