### PR TITLE
X投稿ボタンのドメインを修正し`ref-src`を追加

### DIFF
--- a/app/views/shared/_post_button.html.slim
+++ b/app/views/shared/_post_button.html.slim
@@ -1,4 +1,4 @@
-= link_to "https://twitter.com/intent/tweet?text=#{text}&url=#{url}&hashtags=山手線を徒歩で一周",
+= link_to "https://x.com/intent/tweet?text=#{text}&url=#{url}&button_hashtags=山手線を徒歩で一周&ref_src=twsrc%5Etfw",
   target: '_blank', rel: 'noopener', id: 'post_button',
   class: 'inline-flex items-center justify-center bg-gray-800 hover:bg-gray-400 px-6 text-white rounded-lg h-11' do
     i class="fa-brands fa-x-twitter pr-1"

--- a/spec/system/arrivals_spec.rb
+++ b/spec/system/arrivals_spec.rb
@@ -37,7 +37,7 @@ RSpec.shared_examples 'Arrivals_examples' do |clockwise|
     switch_to_window(windows.last)
     url = URI.decode_www_form_component(current_url)
     expect(url).to have_content '駅に到着しました'
-    expect(url).to have_content '&hashtags=山手線を徒歩で一周'
+    expect(url).to have_content '&button_hashtags=山手線を徒歩で一周'
   end
 
   it '到着時刻を正常な値に編集する' do
@@ -86,7 +86,7 @@ RSpec.shared_examples 'Arrivals_examples' do |clockwise|
     switch_to_window(windows.last)
     url = URI.decode_www_form_component(current_url)
     expect(url).to have_content '山手線30駅全てを歩ききりました'
-    expect(url).to have_content '&hashtags=山手線を徒歩で一周'
+    expect(url).to have_content '&button_hashtags=山手線を徒歩で一周'
   end
 
   it '歩行記録を削除した状態でアクセスする' do


### PR DESCRIPTION
Xに投稿ボタンが表示されないバグ報告があったが、調べたらおそらく広告ブロックが原因っぽい？
https://qiita.com/Takayuki_Nakano/items/bb902ebe044c30ee7a73
解消するには、aタグを使わないというリスクの高そうな方法しかなさそう。

一旦推奨の書き方に合わせる＆ドメインをx.comにする作業だけ行った。
https://help.x.com/ja/using-x/add-x-share-button