### PR TITLE
地図の吹き出しをi18n対応する

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -8,7 +8,6 @@ export default class extends Controller {
     stations: Array,
     arrivedIds: Array,
     currentId: String,
-    stationSuffix: String,
   };
 
   /* eslint-disable no-undef */
@@ -63,7 +62,7 @@ export default class extends Controller {
         icon: L.divIcon({ className: "map-icon" }),
       })
         .addTo(map)
-        .bindPopup(`${station.name}${this.stationSuffixValue}`);
+        .bindPopup(station.name_i18n);
 
       if (station === this.currentStation) {
         pin.openPopup();

--- a/app/views/shared/_map.html.slim
+++ b/app/views/shared/_map.html.slim
@@ -1,5 +1,4 @@
-div[data-controller='map' data-map-stations-value="#{Station.cache_all.to_json}"
+div[data-controller='map' data-map-stations-value="#{Station.cache_all.to_json(methods: :name_i18n)}"
                           data-map-arrived-ids-value="#{station_ids.to_json}"
-                          data-map-current-id-value="#{current_station.id}"
-                          data-map-station-suffix-value="#{t('js.map.station_suffix')}"]
+                          data-map-current-id-value="#{current_station.id}"]
   #map.w-full class='h-[440px] md:h-[500px]'

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -12,5 +12,3 @@ en:
     clipboard:
       success: Copied the URL to clipboard
       error: Failed to copy
-    map:
-      station_suffix: ""

--- a/config/locales/views/shared/ja.yml
+++ b/config/locales/views/shared/ja.yml
@@ -12,5 +12,3 @@ ja:
     clipboard:
       success: 共有用URLをクリップボードにコピーしました
       error: コピーに失敗しました
-    map:
-      station_suffix: 駅


### PR DESCRIPTION
## 概要

map_controller.js で使われている地図の吹き出しをi18n対応する。

## 変更内容

- `_map.html.slim`: `Station.cache_all.to_json(methods: :name_i18n)` でロケール対応した駅名をJSに渡す
- `map_controller.js`: 吹き出しを `station.name_i18n` に変更、不要になった `stationSuffix` value を削除
- `shared/ja.yml` / `en.yml`: 不要になった `js.map.station_suffix` キーを削除

## テスト方法

- 日本語ロケールで地図を開き、ピンの吹き出しに「品川駅」のように駅名が表示されることを確認
- 英語ロケールで地図を開き、吹き出しに「Shinagawa」のように英語駅名が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)