### PR TITLE
利用規約とプライバシーポリシーをi18n対応する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,9 @@ npm run lint   # prettier --check + eslint
 
 ## i18n / 翻訳ファイル
 
-翻訳ファイルの構成は [Railsガイド「ロケールファイルの編成」](https://railsguides.jp/i18n.html#%E3%83%AD%E3%82%B1%E3%83%BC%E3%83%AB%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%AE%E7%B7%A8%E6%88%90) に従う。
+- 翻訳ファイルの構成は [Railsガイド「ロケールファイルの編成」](https://railsguides.jp/i18n.html#%E3%83%AD%E3%82%B1%E3%83%BC%E3%83%AB%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%AE%E7%B7%A8%E6%88%90) に従う。
+- `item1` / `article1` のような連番・抽象的なキー名は使わない
+- キーを見ただけで内容がわかる名前にする
 
 ```
 config/locales/

--- a/app/views/pages/privacy.html.slim
+++ b/app/views/pages/privacy.html.slim
@@ -1,45 +1,45 @@
-- title '利用規約'
-- set_meta_tags description: '利用規約のページです。'
+- title t('.title')
+- set_meta_tags description: t('.meta_description')
 
 .leading-relaxed.text-sm.my-4
-  h2.text-xl.font-bold.text-center.my-2 = title 'プライバシーポリシー'
-  p 「YamaNotes」で提供するサービス（以下,「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。
+  h2.text-xl.font-bold.text-center.my-2 = t('.heading')
+  p = t('.intro')
 
-  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 第1条（個人情報）
-  p 本サービスでは登録およびご利用に際して以下の情報を取得し、それらを個人情報として取り扱います。
+  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 = t('.personal_info.heading')
+  p = t('.personal_info.collected_info_intro')
   ol.list-decimal.pl-6
-    li Googleに関する情報
-    li その他本サービスへのアクセス時に生成されるログ
+    li = t('.personal_info.google_account_info')
+    li = t('.personal_info.access_logs')
 
-  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 第2条（個人情報を収集・利用する目的）
-  p 本サービスが個人情報を収集・利用する目的は，以下のとおりです。
+  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 = t('.purposes_of_use.heading')
+  p = t('.purposes_of_use.purposes_intro')
   ol.list-decimal.pl-6
-    li 本サービスの提供・運営のため
-    li ユーザーからのお問い合わせに回答するため（本人確認を行うことを含む）
-    li メンテナンス，重要なお知らせなど必要に応じたご連絡のため
-    li 利用規約に違反したユーザーや，不正・不当な目的でサービスを利用しようとするユーザーの特定をし，ご利用をお断りするため
-    li ユーザーにご自身の登録情報の閲覧や変更，削除，ご利用状況の閲覧を行っていただくため
-    li 上記の利用目的に付随する目的
+    li = t('.purposes_of_use.service_provision')
+    li = t('.purposes_of_use.respond_to_inquiries')
+    li = t('.purposes_of_use.important_notices')
+    li = t('.purposes_of_use.identify_violators')
+    li = t('.purposes_of_use.user_self_management')
+    li = t('.purposes_of_use.incidental_purposes')
 
-  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 第3条（利用目的の変更）
+  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 = t('.changes_to_purpose.heading')
   ol.list-decimal.pl-6
-    li 利用目的が変更前と関連性を有すると合理的に認められる場合に限り，個人情報の利用目的を変更するものとします。
-    li 利用目的の変更を行った場合には，変更後の目的について，所定の方法により，ユーザーに通知し，または本ウェブサイト上に公表するものとします。
+    li = t('.changes_to_purpose.change_only_when_relevant')
+    li = t('.changes_to_purpose.notify_on_change')
 
-  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 第4条（個人情報の第三者提供）
+  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 = t('.third_party_provision.heading')
   ol.list-decimal.pl-6
-    li 本サービスは，次に掲げる場合を除いて，あらかじめユーザーの同意を得ることなく，第三者に個人情報を提供することはありません。ただし，個人情報保護法その他の法令で認められる場合を除きます。
+    li = t('.third_party_provision.no_third_party_without_consent_intro')
     ol.list-decimal.pl-6
-      li 人の生命，身体または財産の保護のために必要がある場合であって，本人の同意を得ることが困難であるとき
-      li 公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合であって，本人の同意を得ることが困難であるとき
-      li 国の機関もしくは地方公共団体またはその委託を受けた者が法令の定める事務を遂行することに対して協力する必要がある場合であって，本人の同意を得ることにより当該事務の遂行に支障を及ぼすおそれがあるとき
-      li 前項の定めにかかわらず，次に掲げる場合には，当該情報の提供先は第三者に該当しないものとします。
+      li = t('.third_party_provision.protection_of_life')
+      li = t('.third_party_provision.public_health')
+      li = t('.third_party_provision.government_cooperation')
+      li = t('.third_party_provision.exceptions_intro')
       ol.list-decimal.pl-6
-        li 本サービスが利用目的の達成に必要な範囲内において個人情報の取扱いの全部または一部を委託する場合
-        li 合併その他の事由による事業の承継に伴って個人情報が提供される場合
-        li 個人情報を特定の者との間で共同して利用する場合であって，その旨並びに共同して利用される個人情報の項目，共同して利用する者の範囲，利用する者の利用目的および当該個人情報の管理について責任を有する者の氏名または名称について，あらかじめ本人に通知し，または本人が容易に知り得る状態に置いた場合
+        li = t('.third_party_provision.outsourcing')
+        li = t('.third_party_provision.business_succession')
+        li = t('.third_party_provision.joint_use')
 
-  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 第5条（プライバシーポリシーの変更）
+  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 = t('.policy_changes.heading')
   ol.list-decimal.pl-6
-    li 本ポリシーの内容は，法令その他本ポリシーに別段の定めのある事項を除いて，ユーザーに通知することなく，変更することができるものとします。
-    li 本サービスが別途定める場合を除いて，変更後のプライバシーポリシーは，本ウェブサイトに掲載したときから効力を生じるものとします。
+    li = t('.policy_changes.change_without_notice')
+    li = t('.policy_changes.effective_upon_posting')

--- a/app/views/pages/terms.html.slim
+++ b/app/views/pages/terms.html.slim
@@ -1,102 +1,102 @@
-- title '利用規約'
-- set_meta_tags description: '利用規約のページです。'
+- title t('.title')
+- set_meta_tags description: t('.meta_description')
 
-h2.text-xl.font-bold.text-center.my-2 利用規約
+h2.text-xl.font-bold.text-center.my-2 = t('.heading')
 .leading-relaxed.text-sm.my-4
   p
-  | この利用規約（以下，「本規約」といいます。）は，このウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。
-  | 登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。
+  = t('.intro_service_conditions')
+  = t('.intro_user_agreement')
 
-  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 第1条（適用）
+  h3.text-base.my-4.p-1.border-b-2.text-base.border-b-2 = t('.application.heading')
   ol.list-decimal.pl-6
-    li 本規約は，ユーザーと本サービスの利用に関わる一切の関係に適用されるものとします。
-    li 本サービスに関し，本規約のほか，ご利用にあたってのルール等，各種の定め（以下，「個別規定」といいます。）をすることがあります。これら個別規定はその名称のいかんに関わらず，本規約の一部を構成するものとします。
-    li 本規約の規定が前条の個別規定の規定と矛盾する場合には，個別規定において特段の定めなき限り，個別規定の規定が優先されるものとします。
+    li = t('.application.applies_to_all_relations')
+    li = t('.application.individual_provisions_included')
+    li = t('.application.individual_provisions_precedence')
 
-  h3.text-base.my-4.border-b-2.text-base.my-4.border-b-2 第2条（利用登録）
+  h3.text-base.my-4.border-b-2.text-base.my-4.border-b-2 = t('.user_registration.heading')
   ol.list-decimal.pl-6
-    li 本サービスにおいては，登録希望者が本規約に同意の上，利用登録を申請し，本サービスがこれを承認することによって，利用登録が完了するものとします。
-    li 利用登録の申請者に以下の事由があると判断した場合，利用登録の申請を承認しないことがあり，その理由については一切の開示義務を負わないものとします。
+    li = t('.user_registration.registration_process')
+    li = t('.user_registration.rejection_intro')
     ol.pl-6.list-decimal
-      li 利用登録の申請に際して虚偽の事項を届け出た場合
-      li 本規約に違反したことがある者からの申請である場合
-      li その他，利用登録を相当でないと判断した場合
+      li = t('.user_registration.rejection_false_info')
+      li = t('.user_registration.rejection_prior_violation')
+      li = t('.user_registration.rejection_other')
 
-  h3.text-base.my-4.border-b-2 第3条（ユーザーIDおよびパスワードの管理）
-  p 本サービスは、Googleアカウントおよびパスワードの取り扱い関して、Google社の利用規約に準ずるものとします。
+  h3.text-base.my-4.border-b-2 = t('.account_management.heading')
+  p = t('.account_management.follows_google_tos')
 
-  h3.text-base.my-4.border-b-2 第4条（利用料金および支払方法）
-  p ユーザーは本サービスを無料で利用することができます。そのため、料金の支払いに関する取り決めは一切しません。
+  h3.text-base.my-4.border-b-2 = t('.usage_fees.heading')
+  p = t('.usage_fees.free_of_charge')
 
-  h3.text-base.my-4.border-b-2 第5条（禁止事項）
-  p ユーザーは，本サービスの利用にあたり，以下の行為をしてはなりません。
+  h3.text-base.my-4.border-b-2 = t('.prohibited_actions.heading')
+  p = t('.prohibited_actions.intro')
   ol.list-decimal.pl-6
-    li 法令または公序良俗に違反する行為
-    li 犯罪行為に関連する行為
-    li 本サービスの内容等，本サービスに含まれる著作権，商標権ほか知的財産権を侵害する行為
-    li 本サービス，ほかのユーザー，またはその他第三者のサーバーまたはネットワークの機能を破壊したり，妨害したりする行為
-    li 本サービスによって得られた情報を商業的に利用する行為
-    li 本サービスの運営を妨害するおそれのある行為
-    li 不正アクセスをし，またはこれを試みる行為
-    li 他のユーザーに関する個人情報等を収集または蓄積する行為
-    li 不正な目的を持って本サービスを利用する行為
-    li 本サービスの他のユーザーまたはその他の第三者に不利益，損害，不快感を与える行為
-    li 他のユーザーに成りすます行為
-    li 許諾しない本サービス上での宣伝，広告，勧誘，または営業行為
-    li 反社会的勢力に対して直接または間接に利益を供与する行為
-    li その他，不適切と判断する行為
+    li = t('.prohibited_actions.violates_law_or_morals')
+    li = t('.prohibited_actions.criminal_activity')
+    li = t('.prohibited_actions.infringes_ip_rights')
+    li = t('.prohibited_actions.disrupts_network')
+    li = t('.prohibited_actions.commercial_use_of_info')
+    li = t('.prohibited_actions.interferes_with_operation')
+    li = t('.prohibited_actions.unauthorized_access')
+    li = t('.prohibited_actions.collects_personal_info')
+    li = t('.prohibited_actions.improper_purpose')
+    li = t('.prohibited_actions.harms_others')
+    li = t('.prohibited_actions.impersonation')
+    li = t('.prohibited_actions.unauthorized_advertising')
+    li = t('.prohibited_actions.benefits_antisocial_forces')
+    li = t('.prohibited_actions.other_inappropriate')
 
-  h3.text-base.my-4.border-b-2 第6条（本サービスの提供の停止等）
+  h3.text-base.my-4.border-b-2 = t('.service_suspension.heading')
   ol.list-decimal.pl-6
-    li 以下のいずれかの事由があると判断した場合，ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
+    li = t('.service_suspension.suspension_intro')
     ol.list-decimal.pl-6
-      li 本サービスにかかるコンピュータシステムの保守点検または更新を行う場合
-      li 地震，落雷，火災，停電または天災などの不可抗力により，本サービスの提供が困難となった場合
-      li コンピュータまたは通信回線等が事故により停止した場合
-      li その他，本サービスの提供が困難と判断した場合
-    li 本サービスの提供の停止または中断により，ユーザーまたは第三者が被ったいかなる不利益または損害についても，一切の責任を負わないものとします。
+      li = t('.service_suspension.maintenance')
+      li = t('.service_suspension.force_majeure')
+      li = t('.service_suspension.system_failure')
+      li = t('.service_suspension.other_difficulty')
+    li = t('.service_suspension.no_liability_for_suspension')
 
-  h3.text-base.my-4.border-b-2 第7条（利用制限および登録抹消）
+  h3.text-base.my-4.border-b-2 = t('.usage_restriction.heading')
   ol.list-decimal.pl-6
-    li ユーザーが以下のいずれかに該当する場合には，事前の通知なく，ユーザーに対して，本サービスの全部もしくは一部の利用を制限し，またはユーザーとしての登録を抹消することができるものとします。
+    li = t('.usage_restriction.restriction_intro')
     ol.list-decimal.pl-6
-      li 本規約のいずれかの条項に違反した場合
-      li 登録事項に虚偽の事実があることが判明した場合
-      li 連絡に対し，一定期間返答がない場合
-      li 本サービスについて，最終の利用から一定期間利用がない場合
-      li その他，本サービスの利用を適当でないと判断した場合
-    li 本条に基づきユーザーに生じた損害について，一切の責任を負いません。
+      li = t('.usage_restriction.violation_of_terms')
+      li = t('.usage_restriction.false_registration_info')
+      li = t('.usage_restriction.no_response')
+      li = t('.usage_restriction.long_inactive')
+      li = t('.usage_restriction.other_inappropriate_use')
+    li = t('.usage_restriction.no_liability_for_restriction')
 
-  h3.text-base.my-4.border-b-2 第8条（退会）
-  p ユーザーは，本サービスの定める退会手続により，退会できるものとします。
+  h3.text-base.my-4.border-b-2 = t('.withdrawal.heading')
+  p = t('.withdrawal.withdrawal_procedure')
 
-  h3.text-base.my-4.border-b-2 第9条（保証の否認および免責事項）
+  h3.text-base.my-4.border-b-2 = t('.disclaimer.heading')
   ol.list-decimal.pl-6
-    li 本サービスに事実上または法律上の瑕疵（安全性，信頼性，正確性，完全性，有効性，特定の目的への適合性，セキュリティなどに関する欠陥，エラーやバグ，権利侵害などを含みます。）がないことを明示的にも黙示的にも保証しておりません。
-    li 本サービスに起因してユーザーに生じたあらゆる損害について、本サービスの故意又は重過失による場合を除き、一切の責任を負いません。ただし，本サービスに関する本サービスとユーザーとの間の契約（本規約を含みます。）が消費者契約法に定める消費者契約となる場合，この免責規定は適用されません。
-    li 本サービスに関して，ユーザーと他のユーザーまたは第三者との間において生じた取引，連絡または紛争等について一切責任を負いません。
+    li = t('.disclaimer.no_warranty')
+    li = t('.disclaimer.limited_liability')
+    li = t('.disclaimer.no_liability_for_user_disputes')
 
-  h3.text-base.my-4.border-b-2 第10条（サービス内容の変更等）
-  p ユーザーへの事前の告知をもって、本サービスの内容を変更、追加または廃止することがあり、ユーザーはこれを承諾するものとします。
+  h3.text-base.my-4.border-b-2 = t('.service_changes.heading')
+  p = t('.service_changes.changes_with_notice')
 
-  h3.text-base.my-4.border-b-2 第11条（利用規約の変更）
+  h3.text-base.my-4.border-b-2 = t('.terms_changes.heading')
   ol.list-decimal.pl-6
-    li 下の場合には、ユーザーの個別の同意を要せず、本規約を変更することができるものとします。
+    li = t('.terms_changes.change_without_consent_intro')
     ol.list-decimal.pl-6
-      li 本規約の変更がユーザーの一般の利益に適合するとき。
-      li 本規約の変更が本サービス利用契約の目的に反せず、かつ、変更の必要性、変更後の内容の相当性その他の変更に係る事情に照らして合理的なものであるとき。
-    li ユーザーに対し、前項による本規約の変更にあたり、事前に、本規約を変更する旨及び変更後の本規約の内容並びにその効力発生時期を通知します。
+      li = t('.terms_changes.change_for_user_benefit')
+      li = t('.terms_changes.change_reasonable')
+    li = t('.terms_changes.advance_notice_of_change')
 
-  h3.text-base.my-4.border-b-2 第12条（個人情報の取扱い）
-  p 本サービスの利用によって取得する個人情報については，「プライバシーポリシー」に従い適切に取り扱うものとします。
+  h3.text-base.my-4.border-b-2 = t('.personal_info_handling.heading')
+  p = t('.personal_info_handling.follows_privacy_policy')
 
-  h3.text-base.my-4.border-b-2 第13条（通知または連絡）
-  p ユーザーとの間の通知または連絡は，本サービスの定める方法によって行うものとします。
+  h3.text-base.my-4.border-b-2 = t('.notifications.heading')
+  p = t('.notifications.service_defined_method')
 
-  h3.text-base.my-4.border-b-2 第14条（権利義務の譲渡の禁止）
-  p ユーザーは，書面による事前の承諾なく，利用契約上の地位または本規約に基づく権利もしくは義務を第三者に譲渡し，または担保に供することはできません。
+  h3.text-base.my-4.border-b-2 = t('.no_rights_transfer.heading')
+  p = t('.no_rights_transfer.no_transfer_without_consent')
 
-  h3.text-base.my-4.border-b-2 第15条（準拠法・裁判管轄）
+  h3.text-base.my-4.border-b-2 = t('.governing_law.heading')
   ol.list-decimal.pl-4
-    li 本規約の解釈にあたっては，日本法を準拠法とします。
-    li 本サービスに関して紛争が生じた場合には，本サービスの本店所在地を管轄する裁判所を専属的合意管轄とします。
+    li = t('.governing_law.governed_by_japanese_law')
+    li = t('.governing_law.exclusive_jurisdiction')

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -1,6 +1,131 @@
 ---
 en:
   pages:
+    terms:
+      title: Terms of Service
+      meta_description: This is the Terms of Service page.
+      heading: Terms of Service
+      intro_service_conditions: These Terms of Service (hereinafter referred to as "Terms") set forth the conditions of use for the service provided on this website (hereinafter referred to as "Service").
+      intro_user_agreement: Registered users (hereinafter referred to as "Users") shall use the Service in accordance with these Terms.
+      application:
+        heading: Article 1 (Application)
+        applies_to_all_relations: These Terms shall apply to all relationships between Users and the Service related to the use of the Service.
+        individual_provisions_included: In addition to these Terms, the Service may establish various rules (hereinafter referred to as "Individual Provisions") regarding the use of the Service. These Individual Provisions, regardless of their name, shall constitute part of these Terms.
+        individual_provisions_precedence: In the event of conflict between these Terms and the Individual Provisions of the preceding article, the Individual Provisions shall take precedence unless otherwise specified therein.
+      user_registration:
+        heading: Article 2 (User Registration)
+        registration_process: In this Service, user registration is completed when an applicant applies for registration after agreeing to these Terms, and the Service approves such application.
+        rejection_intro: The Service may not approve an application for user registration if it determines that any of the following applies to the applicant, and shall bear no obligation to disclose the reason.
+        rejection_false_info: If false information is provided in the application for user registration
+        rejection_prior_violation: If the application is from a person who has previously violated these Terms
+        rejection_other: In other cases where the Service determines that registration is inappropriate
+      account_management:
+        heading: Article 3 (Management of User ID and Password)
+        follows_google_tos: Regarding the handling of Google accounts and passwords, this Service complies with Google's Terms of Service.
+      usage_fees:
+        heading: Article 4 (Usage Fees and Payment Methods)
+        free_of_charge: Users may use this Service free of charge. Therefore, no arrangements regarding fee payments shall be made.
+      prohibited_actions:
+        heading: Article 5 (Prohibited Actions)
+        intro: Users shall not engage in any of the following actions when using the Service.
+        violates_law_or_morals: Actions that violate laws or public order and morals
+        criminal_activity: Actions related to criminal activities
+        infringes_ip_rights: Actions that infringe on copyrights, trademarks, or other intellectual property rights contained in the Service
+        disrupts_network: Actions that destroy or interfere with the functions of the servers or networks of the Service, other Users, or other third parties
+        commercial_use_of_info: Actions that commercially exploit information obtained through the Service
+        interferes_with_operation: Actions that may interfere with the operation of the Service
+        unauthorized_access: Unauthorized access or attempts thereof
+        collects_personal_info: Collecting or accumulating personal information of other Users
+        improper_purpose: Using the Service for improper purposes
+        harms_others: Actions that cause disadvantage, damage, or discomfort to other Users or third parties
+        impersonation: Impersonating other Users
+        unauthorized_advertising: Advertising, promotional, solicitation, or sales activities on the Service without authorization
+        benefits_antisocial_forces: Directly or indirectly providing benefits to antisocial forces
+        other_inappropriate: Other actions deemed inappropriate
+      service_suspension:
+        heading: Article 6 (Suspension of Service)
+        suspension_intro: The Service may suspend or interrupt all or part of the Service without prior notice to Users if any of the following applies.
+        maintenance: When performing maintenance, inspection, or updates of the computer systems related to the Service
+        force_majeure: When provision of the Service becomes difficult due to force majeure such as earthquake, lightning, fire, power outage, or natural disaster
+        system_failure: When computers or communication lines are stopped due to an accident
+        other_difficulty: In other cases where the Service determines that provision is difficult
+        no_liability_for_suspension: The Service shall bear no responsibility for any disadvantage or damage suffered by Users or third parties due to the suspension or interruption of the Service.
+      usage_restriction:
+        heading: Article 7 (Restriction of Use and Cancellation of Registration)
+        restriction_intro: The Service may, without prior notice, restrict all or part of the use of the Service or cancel a User's registration if any of the following applies.
+        violation_of_terms: If any provision of these Terms is violated
+        false_registration_info: If it is found that registration information contains false facts
+        no_response: If there is no response to contact for a certain period
+        long_inactive: If the Service has not been used for a certain period since the last use
+        other_inappropriate_use: In other cases where the Service determines that use is inappropriate
+        no_liability_for_restriction: The Service shall bear no responsibility for any damage caused to Users based on this article.
+      withdrawal:
+        heading: Article 8 (Withdrawal)
+        withdrawal_procedure: Users may withdraw from the Service by following the withdrawal procedures specified by the Service.
+      disclaimer:
+        heading: Article 9 (Disclaimer of Warranty and Limitation of Liability)
+        no_warranty: The Service makes no express or implied warranty that the Service is free from factual or legal defects (including defects related to safety, reliability, accuracy, completeness, effectiveness, fitness for a particular purpose, security, errors, bugs, or rights infringement).
+        limited_liability: The Service shall bear no responsibility for any damage caused to Users arising from the Service, except in cases of intentional or gross negligence. However, this disclaimer shall not apply if the contract between the Service and the User regarding the Service (including these Terms) constitutes a consumer contract as defined by the Consumer Contract Act.
+        no_liability_for_user_disputes: The Service shall bear no responsibility for any transactions, communications, or disputes between Users and other Users or third parties in connection with the Service.
+      service_changes:
+        heading: Article 10 (Changes to Service Content)
+        changes_with_notice: The Service may change, add to, or discontinue the content of the Service with prior notice to Users, and Users shall agree to this.
+      terms_changes:
+        heading: Article 11 (Changes to Terms of Service)
+        change_without_consent_intro: The Service may change these Terms without the individual consent of Users in the following cases.
+        change_for_user_benefit: When the change to these Terms is in the general interest of Users.
+        change_reasonable: When the change to these Terms is not contrary to the purpose of the Service agreement and is reasonable in light of the necessity of the change, the appropriateness of the content after the change, and other circumstances related to the change.
+        advance_notice_of_change: The Service shall notify Users in advance of changes to these Terms pursuant to the preceding paragraph, including the fact of the change, the content of the revised Terms, and the effective date.
+      personal_info_handling:
+        heading: Article 12 (Handling of Personal Information)
+        follows_privacy_policy: Personal information obtained through the use of the Service shall be handled appropriately in accordance with the "Privacy Policy."
+      notifications:
+        heading: Article 13 (Notifications and Communications)
+        service_defined_method: Notifications or communications between the Service and Users shall be made by methods specified by the Service.
+      no_rights_transfer:
+        heading: Article 14 (Prohibition of Transfer of Rights and Obligations)
+        no_transfer_without_consent: Users may not transfer or use as collateral their position under the service agreement or rights or obligations under these Terms to any third party without prior written consent.
+      governing_law:
+        heading: Article 15 (Governing Law and Jurisdiction)
+        governed_by_japanese_law: These Terms shall be governed by and construed in accordance with the laws of Japan.
+        exclusive_jurisdiction: In the event of any dispute related to the Service, the court having jurisdiction over the location of the Service's principal office shall have exclusive agreed jurisdiction.
+    privacy:
+      title: Privacy Policy
+      meta_description: This is the Privacy Policy page.
+      heading: Privacy Policy
+      intro: "\"YamaNotes\" establishes the following Privacy Policy (hereinafter referred to as \"Policy\") regarding the handling of users' personal information in the service provided (hereinafter referred to as \"Service\")."
+      personal_info:
+        heading: Article 1 (Personal Information)
+        collected_info_intro: The Service collects the following information upon registration and use, and handles it as personal information.
+        google_account_info: Information related to Google
+        access_logs: Other logs generated when accessing the Service
+      purposes_of_use:
+        heading: Article 2 (Purpose of Collecting and Using Personal Information)
+        purposes_intro: The purposes for which the Service collects and uses personal information are as follows.
+        service_provision: For the provision and operation of the Service
+        respond_to_inquiries: To respond to inquiries from Users (including identity verification)
+        important_notices: For necessary communications such as maintenance and important notices
+        identify_violators: To identify Users who violate the Terms of Service or who attempt to use the Service for fraudulent or improper purposes, and to refuse their use
+        user_self_management: To allow Users to view, modify, delete their own registration information, and view their usage status
+        incidental_purposes: For purposes incidental to the above purposes
+      changes_to_purpose:
+        heading: Article 3 (Changes to Purpose of Use)
+        change_only_when_relevant: The purpose of use of personal information shall be changed only when reasonably deemed to have relevance to the purpose before the change.
+        notify_on_change: When the purpose of use is changed, the User shall be notified of the changed purpose by specified methods or announced on this website.
+      third_party_provision:
+        heading: Article 4 (Provision of Personal Information to Third Parties)
+        no_third_party_without_consent_intro: The Service shall not provide personal information to third parties without the prior consent of the User, except in the following cases. However, this excludes cases permitted by the Personal Information Protection Act and other laws.
+        protection_of_life: When necessary for the protection of a person's life, body, or property, and it is difficult to obtain the consent of the individual
+        public_health: When particularly necessary for improving public health or promoting the sound development of children, and it is difficult to obtain the consent of the individual
+        government_cooperation: When it is necessary to cooperate with national or local government agencies, or persons entrusted by them, in carrying out affairs stipulated by law, and obtaining the individual's consent may impede such affairs
+        exceptions_intro: Notwithstanding the preceding paragraph, the recipient of such information shall not be deemed a third party in the following cases.
+        outsourcing: When the Service entrusts all or part of the handling of personal information to the extent necessary to achieve the purpose of use
+        business_succession: When personal information is provided in connection with business succession due to merger or other reasons
+        joint_use: When personal information is jointly used with a specific party, and the individual has been notified in advance or placed in a readily accessible state regarding the fact of joint use, the items of personal information jointly used, the scope of joint users, the purpose of use by such users, and the name or title of the person responsible for managing the personal information
+      policy_changes:
+        heading: Article 5 (Changes to Privacy Policy)
+        change_without_notice: The content of this Policy may be changed without notice to Users, except as otherwise provided by law or this Policy.
+        effective_upon_posting: Unless otherwise specified by the Service, the revised Privacy Policy shall take effect when posted on this website.
     top:
       title: Top page
       catchcopy_line1: Challenge yourself to walk

--- a/config/locales/views/pages/ja.yml
+++ b/config/locales/views/pages/ja.yml
@@ -1,6 +1,131 @@
 ---
 ja:
   pages:
+    terms:
+      title: 利用規約
+      meta_description: 利用規約のページです。
+      heading: 利用規約
+      intro_service_conditions: この利用規約（以下，「本規約」といいます。）は，このウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。
+      intro_user_agreement: 登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。
+      application:
+        heading: 第1条（適用）
+        applies_to_all_relations: 本規約は，ユーザーと本サービスの利用に関わる一切の関係に適用されるものとします。
+        individual_provisions_included: 本サービスに関し，本規約のほか，ご利用にあたってのルール等，各種の定め（以下，「個別規定」といいます。）をすることがあります。これら個別規定はその名称のいかんに関わらず，本規約の一部を構成するものとします。
+        individual_provisions_precedence: 本規約の規定が前条の個別規定の規定と矛盾する場合には，個別規定において特段の定めなき限り，個別規定の規定が優先されるものとします。
+      user_registration:
+        heading: 第2条（利用登録）
+        registration_process: 本サービスにおいては，登録希望者が本規約に同意の上，利用登録を申請し，本サービスがこれを承認することによって，利用登録が完了するものとします。
+        rejection_intro: 利用登録の申請者に以下の事由があると判断した場合，利用登録の申請を承認しないことがあり，その理由については一切の開示義務を負わないものとします。
+        rejection_false_info: 利用登録の申請に際して虚偽の事項を届け出た場合
+        rejection_prior_violation: 本規約に違反したことがある者からの申請である場合
+        rejection_other: その他，利用登録を相当でないと判断した場合
+      account_management:
+        heading: 第3条（ユーザーIDおよびパスワードの管理）
+        follows_google_tos: 本サービスは、Googleアカウントおよびパスワードの取り扱い関して、Google社の利用規約に準ずるものとします。
+      usage_fees:
+        heading: 第4条（利用料金および支払方法）
+        free_of_charge: ユーザーは本サービスを無料で利用することができます。そのため、料金の支払いに関する取り決めは一切しません。
+      prohibited_actions:
+        heading: 第5条（禁止事項）
+        intro: ユーザーは，本サービスの利用にあたり，以下の行為をしてはなりません。
+        violates_law_or_morals: 法令または公序良俗に違反する行為
+        criminal_activity: 犯罪行為に関連する行為
+        infringes_ip_rights: 本サービスの内容等，本サービスに含まれる著作権，商標権ほか知的財産権を侵害する行為
+        disrupts_network: 本サービス，ほかのユーザー，またはその他第三者のサーバーまたはネットワークの機能を破壊したり，妨害したりする行為
+        commercial_use_of_info: 本サービスによって得られた情報を商業的に利用する行為
+        interferes_with_operation: 本サービスの運営を妨害するおそれのある行為
+        unauthorized_access: 不正アクセスをし，またはこれを試みる行為
+        collects_personal_info: 他のユーザーに関する個人情報等を収集または蓄積する行為
+        improper_purpose: 不正な目的を持って本サービスを利用する行為
+        harms_others: 本サービスの他のユーザーまたはその他の第三者に不利益，損害，不快感を与える行為
+        impersonation: 他のユーザーに成りすます行為
+        unauthorized_advertising: 許諾しない本サービス上での宣伝，広告，勧誘，または営業行為
+        benefits_antisocial_forces: 反社会的勢力に対して直接または間接に利益を供与する行為
+        other_inappropriate: その他，不適切と判断する行為
+      service_suspension:
+        heading: 第6条（本サービスの提供の停止等）
+        suspension_intro: 以下のいずれかの事由があると判断した場合，ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
+        maintenance: 本サービスにかかるコンピュータシステムの保守点検または更新を行う場合
+        force_majeure: 地震，落雷，火災，停電または天災などの不可抗力により，本サービスの提供が困難となった場合
+        system_failure: コンピュータまたは通信回線等が事故により停止した場合
+        other_difficulty: その他，本サービスの提供が困難と判断した場合
+        no_liability_for_suspension: 本サービスの提供の停止または中断により，ユーザーまたは第三者が被ったいかなる不利益または損害についても，一切の責任を負わないものとします。
+      usage_restriction:
+        heading: 第7条（利用制限および登録抹消）
+        restriction_intro: ユーザーが以下のいずれかに該当する場合には，事前の通知なく，ユーザーに対して，本サービスの全部もしくは一部の利用を制限し，またはユーザーとしての登録を抹消することができるものとします。
+        violation_of_terms: 本規約のいずれかの条項に違反した場合
+        false_registration_info: 登録事項に虚偽の事実があることが判明した場合
+        no_response: 連絡に対し，一定期間返答がない場合
+        long_inactive: 本サービスについて，最終の利用から一定期間利用がない場合
+        other_inappropriate_use: その他，本サービスの利用を適当でないと判断した場合
+        no_liability_for_restriction: 本条に基づきユーザーに生じた損害について，一切の責任を負いません。
+      withdrawal:
+        heading: 第8条（退会）
+        withdrawal_procedure: ユーザーは，本サービスの定める退会手続により，退会できるものとします。
+      disclaimer:
+        heading: 第9条（保証の否認および免責事項）
+        no_warranty: 本サービスに事実上または法律上の瑕疵（安全性，信頼性，正確性，完全性，有効性，特定の目的への適合性，セキュリティなどに関する欠陥，エラーやバグ，権利侵害などを含みます。）がないことを明示的にも黙示的にも保証しておりません。
+        limited_liability: 本サービスに起因してユーザーに生じたあらゆる損害について、本サービスの故意又は重過失による場合を除き、一切の責任を負いません。ただし，本サービスに関する本サービスとユーザーとの間の契約（本規約を含みます。）が消費者契約法に定める消費者契約となる場合，この免責規定は適用されません。
+        no_liability_for_user_disputes: 本サービスに関して，ユーザーと他のユーザーまたは第三者との間において生じた取引，連絡または紛争等について一切責任を負いません。
+      service_changes:
+        heading: 第10条（サービス内容の変更等）
+        changes_with_notice: ユーザーへの事前の告知をもって、本サービスの内容を変更、追加または廃止することがあり、ユーザーはこれを承諾するものとします。
+      terms_changes:
+        heading: 第11条（利用規約の変更）
+        change_without_consent_intro: 下の場合には、ユーザーの個別の同意を要せず、本規約を変更することができるものとします。
+        change_for_user_benefit: 本規約の変更がユーザーの一般の利益に適合するとき。
+        change_reasonable: 本規約の変更が本サービス利用契約の目的に反せず、かつ、変更の必要性、変更後の内容の相当性その他の変更に係る事情に照らして合理的なものであるとき。
+        advance_notice_of_change: ユーザーに対し、前項による本規約の変更にあたり、事前に、本規約を変更する旨及び変更後の本規約の内容並びにその効力発生時期を通知します。
+      personal_info_handling:
+        heading: 第12条（個人情報の取扱い）
+        follows_privacy_policy: 本サービスの利用によって取得する個人情報については，「プライバシーポリシー」に従い適切に取り扱うものとします。
+      notifications:
+        heading: 第13条（通知または連絡）
+        service_defined_method: ユーザーとの間の通知または連絡は，本サービスの定める方法によって行うものとします。
+      no_rights_transfer:
+        heading: 第14条（権利義務の譲渡の禁止）
+        no_transfer_without_consent: ユーザーは，書面による事前の承諾なく，利用契約上の地位または本規約に基づく権利もしくは義務を第三者に譲渡し，または担保に供することはできません。
+      governing_law:
+        heading: 第15条（準拠法・裁判管轄）
+        governed_by_japanese_law: 本規約の解釈にあたっては，日本法を準拠法とします。
+        exclusive_jurisdiction: 本サービスに関して紛争が生じた場合には，本サービスの本店所在地を管轄する裁判所を専属的合意管轄とします。
+    privacy:
+      title: プライバシーポリシー
+      meta_description: プライバシーポリシーのページです。
+      heading: プライバシーポリシー
+      intro: 「YamaNotes」で提供するサービス（以下,「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。
+      personal_info:
+        heading: 第1条（個人情報）
+        collected_info_intro: 本サービスでは登録およびご利用に際して以下の情報を取得し、それらを個人情報として取り扱います。
+        google_account_info: Googleに関する情報
+        access_logs: その他本サービスへのアクセス時に生成されるログ
+      purposes_of_use:
+        heading: 第2条（個人情報を収集・利用する目的）
+        purposes_intro: 本サービスが個人情報を収集・利用する目的は，以下のとおりです。
+        service_provision: 本サービスの提供・運営のため
+        respond_to_inquiries: ユーザーからのお問い合わせに回答するため（本人確認を行うことを含む）
+        important_notices: メンテナンス，重要なお知らせなど必要に応じたご連絡のため
+        identify_violators: 利用規約に違反したユーザーや，不正・不当な目的でサービスを利用しようとするユーザーの特定をし，ご利用をお断りするため
+        user_self_management: ユーザーにご自身の登録情報の閲覧や変更，削除，ご利用状況の閲覧を行っていただくため
+        incidental_purposes: 上記の利用目的に付随する目的
+      changes_to_purpose:
+        heading: 第3条（利用目的の変更）
+        change_only_when_relevant: 利用目的が変更前と関連性を有すると合理的に認められる場合に限り，個人情報の利用目的を変更するものとします。
+        notify_on_change: 利用目的の変更を行った場合には，変更後の目的について，所定の方法により，ユーザーに通知し，または本ウェブサイト上に公表するものとします。
+      third_party_provision:
+        heading: 第4条（個人情報の第三者提供）
+        no_third_party_without_consent_intro: 本サービスは，次に掲げる場合を除いて，あらかじめユーザーの同意を得ることなく，第三者に個人情報を提供することはありません。ただし，個人情報保護法その他の法令で認められる場合を除きます。
+        protection_of_life: 人の生命，身体または財産の保護のために必要がある場合であって，本人の同意を得ることが困難であるとき
+        public_health: 公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合であって，本人の同意を得ることが困難であるとき
+        government_cooperation: 国の機関もしくは地方公共団体またはその委託を受けた者が法令の定める事務を遂行することに対して協力する必要がある場合であって，本人の同意を得ることにより当該事務の遂行に支障を及ぼすおそれがあるとき
+        exceptions_intro: 前項の定めにかかわらず，次に掲げる場合には，当該情報の提供先は第三者に該当しないものとします。
+        outsourcing: 本サービスが利用目的の達成に必要な範囲内において個人情報の取扱いの全部または一部を委託する場合
+        business_succession: 合併その他の事由による事業の承継に伴って個人情報が提供される場合
+        joint_use: 個人情報を特定の者との間で共同して利用する場合であって，その旨並びに共同して利用される個人情報の項目，共同して利用する者の範囲，利用する者の利用目的および当該個人情報の管理について責任を有する者の氏名または名称について，あらかじめ本人に通知し，または本人が容易に知り得る状態に置いた場合
+      policy_changes:
+        heading: 第5条（プライバシーポリシーの変更）
+        change_without_notice: 本ポリシーの内容は，法令その他本ポリシーに別段の定めのある事項を除いて，ユーザーに通知することなく，変更することができるものとします。
+        effective_upon_posting: 本サービスが別途定める場合を除いて，変更後のプライバシーポリシーは，本ウェブサイトに掲載したときから効力を生じるものとします。
     top:
       title: トップページ
       catchcopy_line1: 徒歩で山手線一周に


### PR DESCRIPTION
## 概要

ハードコードされていた利用規約・プライバシーポリシーのテキストをi18n対応した。

PoC: https://github.com/SuzukaHori/YamaNotes/pull/259

## 変更内容

- `app/views/pages/terms.html.slim` / `privacy.html.slim` のテキストをすべて `t('.キー名')` に置き換え
- `config/locales/views/pages/ja.yml` / `en.yml` に翻訳キーを追加
- 翻訳キーは `item1` / `article1` のような連番ではなく、内容がわかる名前を使用（例: `prohibited_actions`、`service_suspension`）
- CLAUDE.md にi18n翻訳キーの命名規則を追記

## テスト方法

- `bin/dev` でサーバーを起動し、`/terms` と `/privacy` を日本語・英語で表示して内容が正しく表示されることを確認