### PR TITLE
英語キーワードでの検索対応のためSEOを改善する

### DIFF
--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -6,8 +6,8 @@ module MetaTagsHelper
       site: 'YamaNotes',
       reverse: true,
       charset: 'utf-8',
-      description: '山手線一周に徒歩で挑戦する人のための記録アプリ',
-      keywords: '山手線一周,山手線,徒歩',
+      description: '山手線一周に徒歩で挑戦する人のための記録アプリ | Yamanote Line walking challenge app',
+      keywords: '山手線一周,山手線,徒歩,Yamanote line walking challenge,Yamanote line',
       separator: '|',
       og:,
       twitter:
@@ -24,7 +24,7 @@ module MetaTagsHelper
       type: 'website',
       url: request.url,
       image: image_url('ogp.png'),
-      local: 'ja-JP'
+      locale: 'ja_JP'
     }
   end
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,5 +1,5 @@
 doctype html
-html  class='text-base-black'
+html lang=I18n.locale class='text-base-black'
   head
     meta name='viewport' content='width=device-width,initial-scale=1'
     = display_meta_tags(default_meta_tags)

--- a/app/views/pages/top.html.slim
+++ b/app/views/pages/top.html.slim
@@ -1,4 +1,5 @@
 - title t('.title')
+- set_meta_tags description: t('.meta_description')
 .mx-4.my-8.md:mx-10
   .text-center
     p.text-yamanote-green-150.text-2xl.md:text-3xl.font-pop

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -128,6 +128,7 @@ en:
         effective_upon_posting: Unless otherwise specified by the Service, the revised Privacy Policy shall take effect when posted on this website.
     top:
       title: Top page
+      meta_description: YamaNotes is a free app to record your Yamanote Line walking challenge. Track arrival times, view progress on a map, and share your journey.
       catchcopy_line1: Challenge yourself to walk
       catchcopy_line2: the entire Yamanote Line!!
       description_line1: YamaNotes is a record-keeping app

--- a/config/locales/views/pages/ja.yml
+++ b/config/locales/views/pages/ja.yml
@@ -128,6 +128,7 @@ ja:
         effective_upon_posting: 本サービスが別途定める場合を除いて，変更後のプライバシーポリシーは，本ウェブサイトに掲載したときから効力を生じるものとします。
     top:
       title: トップページ
+      meta_description: ヤマノートは山手線一周徒歩チャレンジを記録する無料アプリです。到着時刻の記録・地図での進捗確認・記録の共有ができます。
       catchcopy_line1: 徒歩で山手線一周に
       catchcopy_line2: 挑戦しよう！！
       description_line1: ヤマノートは山手線一周に徒歩で

--- a/spec/helpers/meta_tags_helper_spec.rb
+++ b/spec/helpers/meta_tags_helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MetaTagsHelper, type: :helper do
   it '#default_meta_tags' do
     tag = default_meta_tags
     expect(tag[:site]).to eq('YamaNotes')
-    expect(tag[:description]).to eq('山手線一周に徒歩で挑戦する人のための記録アプリ')
+    expect(tag[:description]).to eq('山手線一周に徒歩で挑戦する人のための記録アプリ | Yamanote Line walking challenge app')
     expect(tag[:twitter][:image]).to include('ogp.png')
   end
 end


### PR DESCRIPTION
## 概要

英語で「Yamanote line walking challenge」などのキーワードで検索した際に検索結果に表示されるよう、SEOを改善する。

## 変更内容

- `meta description` と `keywords` に英語キーワードを追加
- トップページに固有の `meta description` を設定（日英両対応）
- `<html lang>` 属性を `I18n.locale` に応じて動的に設定
- `og:locale` のタイポ修正（`local: 'ja-JP'` → `locale: 'ja_JP'`）

## テスト方法

1. `bin/dev` で開発サーバーを起動
2. トップページ（`/`）のHTMLソースで以下を確認
   - `<html lang="ja">` が出力されている
   - `<meta name="description">` に日本語・英語両方のキーワードが含まれている
   - `<meta property="og:locale" content="ja_JP">` が出力されている
3. `bundle exec rspec` でテストが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)