### PR TITLE
fix: @tailwindcss/formsプラグインを追加してフォームとダイアログのデザイン崩れを修正する

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@plugin '@tailwindcss/forms';
 @config '../../../config/tailwind.config.js';
 
 /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@tailwindcss/forms": "^0.5.11",
         "caniuse-lite": "^1.0.30001632",
         "leaflet": "^1.9.4",
         "tailwindcss-stimulus-components": "^5.1.1"
@@ -158,6 +159,17 @@
       "dev": true,
       "peerDependencies": {
         "prettier": "^3.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.11.tgz",
+      "integrity": "sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA==",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
       }
     },
     "node_modules/@types/json5": {
@@ -1945,6 +1957,14 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2557,6 +2577,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "peer": true
     },
     "node_modules/tailwindcss-stimulus-components": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "fix": "prettier --write 'app/javascript/**/*.js'"
   },
   "dependencies": {
+    "@tailwindcss/forms": "^0.5.11",
     "caniuse-lite": "^1.0.30001632",
     "leaflet": "^1.9.4",
     "tailwindcss-stimulus-components": "^5.1.1"


### PR DESCRIPTION
## 概要

TailwindCSS v4へのアップグレード(#287)で `@tailwindcss/forms` プラグインが削除されたため、フォーム要素のベーススタイルが失われデザインが崩れていた問題を修正する。

## 変更内容

- `app/assets/tailwind/application.css` に `@plugin '@tailwindcss/forms';` を追加
- `package.json` の `dependencies` に `@tailwindcss/forms@^0.5.11` を追加
- `package-lock.json` を更新

## 原因

`@tailwindcss/forms` は `input` / `textarea` / `select` / `checkbox` / `radio` などのフォーム要素に対してクロスブラウザ対応のベーススタイルリセットを提供するプラグイン。#287 の v4 アップグレード時に削除されたことで、これらの要素のデザインが崩れていた。

v0.5.11 で Tailwind v4 に対応済みで、v4 の `@plugin` 構文で読み込める。

## テスト方法

- [x] `bin/dev` で開発サーバーを起動する
- [x] Walk 作成フォーム（出発駅選択セレクト、時計回り/反時計回りラジオボタン）が正しく表示される
- [x] 到着編集フォーム（時刻セレクト、メモ textarea）が正しく表示される
- [x] メモダイアログの textarea が正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)