### PR TITLE
ダイアログが左寄りになる問題を修正する

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -53,7 +53,7 @@
 
 @layer components {
   dialog {
-    @apply text-base-black;
+    @apply text-base-black mx-auto my-auto;
   }
 
   dialog.slideover[open] ul {


### PR DESCRIPTION
## 概要

PR #287 (TailwindCSS v4 アップグレード) の影響で、ダイアログが左寄りに表示されるようになった問題を修正します。

## 変更内容

- `app/assets/tailwind/application.css` の `dialog` ベーススタイルに `mx-auto my-auto` を追加

**原因**: TailwindCSS v4 の Preflight で `<dialog>` 要素の `margin` がリセットされ、ブラウザデフォルトの `margin: auto` が効かなくなっていた。v3 では `<dialog>` はリセット対象外だったため問題が出ていなかった。

## テスト方法

- `bin/dev` を起動し、各種ダイアログ(`_caution` / `_help` / `_memo` / `_menu`)が画面中央に表示されることを確認