### PR TITLE
@tailwindcss/forms への依存を除去する

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -23,19 +23,6 @@
   --color-base-black: #4f4f64;
 }
 
-/*
-  v3 から v4 で border のデフォルト色が `currentcolor` に変わったため、
-  既存スタイルを維持するための互換レイヤー。
-*/
-@layer base {
-  *,
-  ::after,
-  ::before,
-  ::backdrop,
-  ::file-selector-button {
-    border-color: var(--color-gray-200, currentcolor);
-  }
-}
 
 @layer base {
   @font-face {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,5 +1,4 @@
 @import 'tailwindcss';
-@plugin '@tailwindcss/forms';
 
 @theme {
   --font-pop: 'Mochiy Pop One', sans-serif;
@@ -44,6 +43,170 @@
     src: url('../fonts/Mochiy_Pop_One.woff');
   }
 }
+
+/*
+  @tailwindcss/forms が提供していたフォームリセットを明示化したもの。
+  ブラウザのデフォルトスタイルを均一化し、Tailwind ユーティリティで上書きしやすくする。
+*/
+
+/* テキスト系 input / select / textarea: appearance リセット・border・padding の統一 */
+@layer base {
+  input:where([type='text']),
+  input:where(:not([type])),
+  input:where([type='email']),
+  input:where([type='url']),
+  input:where([type='password']),
+  input:where([type='number']),
+  input:where([type='date']),
+  input:where([type='datetime-local']),
+  input:where([type='month']),
+  input:where([type='search']),
+  input:where([type='tel']),
+  input:where([type='time']),
+  input:where([type='week']),
+  select,
+  textarea {
+    appearance: none;
+    background-color: #fff;
+    border-color: rgb(107 114 128); /* gray-500: トップの * { border-color: gray-200 } を上書き */
+    border-width: 1px;
+    border-radius: 0;
+    padding: 0.5rem 0.75rem;
+    font-size: 1rem;
+    line-height: 1.5rem;
+  }
+
+  /* フォーカス時: outline を透明にして box-shadow でリングを表現 */
+  input:where([type='text']):focus,
+  input:where(:not([type])):focus,
+  input:where([type='email']):focus,
+  input:where([type='url']):focus,
+  input:where([type='password']):focus,
+  input:where([type='number']):focus,
+  input:where([type='date']):focus,
+  input:where([type='datetime-local']):focus,
+  input:where([type='month']):focus,
+  input:where([type='search']):focus,
+  input:where([type='tel']):focus,
+  input:where([type='time']):focus,
+  input:where([type='week']):focus,
+  select:focus,
+  textarea:focus {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 0px #fff, 0 0 0 1px rgb(37 99 235 / 0.5), 0 0 #0000;
+    border-color: rgb(37 99 235); /* blue-600 */
+  }
+
+  /* placeholder の色を gray-500 に統一（ブラウザ差異の吸収） */
+  input::placeholder,
+  textarea::placeholder {
+    color: rgb(107 114 128); /* gray-500 */
+    opacity: 1;
+  }
+}
+
+/* select: ブラウザネイティブの矢印を非表示にして SVG の chevron アイコンを表示 */
+@layer base {
+  select {
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+    background-position: right 0.5rem center;
+    background-repeat: no-repeat;
+    background-size: 1.5em 1.5em;
+    padding-right: 2.5rem;
+    print-color-adjust: exact;
+  }
+
+  /* multiple / size 付き select はリスト表示なので chevron を外す */
+  select:where([multiple]),
+  select:where([size]:not([size='1'])) {
+    background-image: initial;
+    background-position: initial;
+    background-repeat: unset;
+    background-size: initial;
+    padding-right: 0.75rem;
+    print-color-adjust: unset;
+  }
+}
+
+/* time_select: WebKit の日時フィールド pseudo-element の余分な padding を除去 */
+@layer base {
+  ::-webkit-datetime-edit-fields-wrapper { padding: 0; }
+  ::-webkit-date-and-time-value { min-height: 1.5em; text-align: inherit; }
+  ::-webkit-datetime-edit { display: inline-flex; }
+  ::-webkit-datetime-edit,
+  ::-webkit-datetime-edit-year-field,
+  ::-webkit-datetime-edit-month-field,
+  ::-webkit-datetime-edit-day-field,
+  ::-webkit-datetime-edit-hour-field,
+  ::-webkit-datetime-edit-minute-field,
+  ::-webkit-datetime-edit-second-field,
+  ::-webkit-datetime-edit-millisecond-field,
+  ::-webkit-datetime-edit-meridiem-field {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}
+
+/*
+  checkbox / radio: appearance リセットとチェック時の塗りつぶし。
+  `color` に text-{color} クラスの値が入り、checked 時に background-color: currentColor で
+  その色が塗られる（例: text-dark-blue-200 → チェック時に dark-blue-200 色になる）。
+*/
+@layer base {
+  input:where([type='checkbox']),
+  input:where([type='radio']) {
+    appearance: none;
+    padding: 0;
+    print-color-adjust: exact;
+    display: inline-block;
+    vertical-align: middle;
+    background-origin: border-box;
+    user-select: none;
+    flex-shrink: 0;
+    height: 1rem;
+    width: 1rem;
+    color: rgb(37 99 235); /* blue-600 デフォルト。text-{color} クラスで上書き可 */
+    background-color: #fff;
+    border-color: rgb(107 114 128); /* gray-500 */
+    border-width: 1px;
+  }
+
+  input:where([type='checkbox']) { border-radius: 0; }
+  input:where([type='radio'])    { border-radius: 100%; }
+
+  input:where([type='checkbox']):focus,
+  input:where([type='radio']):focus {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    box-shadow: 0 0 0 2px #fff, 0 0 0 4px rgb(37 99 235), 0 0 #0000;
+  }
+
+  /* チェック時: currentColor（= text-{color} の値）で塗りつぶし、SVG アイコンを重ねる */
+  input:where([type='checkbox']):checked,
+  input:where([type='radio']):checked,
+  input:where([type='checkbox']):checked:hover,
+  input:where([type='checkbox']):checked:focus,
+  input:where([type='radio']):checked:hover,
+  input:where([type='radio']):checked:focus {
+    border-color: transparent;
+    background-color: currentColor;
+    background-size: 100% 100%;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+
+  input:where([type='checkbox']):checked {
+    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+  }
+
+  input:where([type='radio']):checked {
+    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
+  }
+}
+
+
+/* ========== カスタム設定 ========== */
 
 @utility btn-primary {
   @apply inline-flex items-center justify-center px-6 py-2 bg-bright-orange-100 text-white rounded-lg shadow-sm transition-all duration-200 ease-out hover:bg-bright-orange-50 focus:outline-hidden focus:ring-3 focus:ring-red-400/75 h-11 cursor-pointer;

--- a/app/views/walks/edit.html.slim
+++ b/app/views/walks/edit.html.slim
@@ -9,7 +9,7 @@
     = form_with model: @walk, class: 'inline-block', method: :patch do |f|
       = f.label :publish
         = f.check_box :publish, { class: 'sr-only peer', onchange: 'this.form.requestSubmit()' }, 'true', 'false'
-        .toggle-switch.cursor-pointer
+        div class='toggle-switch cursor-pointer [&::after]:border-gray-200'
   - if !@walk.publish
     p.text-xs.text-gray-500.mt-4
       = t('.public_hint')

--- a/app/views/walks/new.html.slim
+++ b/app/views/walks/new.html.slim
@@ -2,7 +2,7 @@
 - set_meta_tags description: '一周の設定をするページです'
 
 h2.text-lg.mt-10.mb-2.text-center = t('.welcome')
-= tag.div class: 'mb-10 mx-auto py-8 px-6 border-4 text-lg text-center md:w-2/3',
+= tag.div class: 'mb-10 mx-auto py-8 px-6 border-4 border-gray-200 text-lg text-center md:w-2/3',
           data: { controller: 'introduction',
                   introduction_initial_station_value: Station.cache_all.first.name_i18n,
                   introduction_initial_clockwise_mode_value: Walk.human_attribute_name(:clockwise),

--- a/app/views/walks/new/_page1.html.slim
+++ b/app/views/walks/new/_page1.html.slim
@@ -1,7 +1,7 @@
 #page-1 data-pagination-target="page"
   h3.mb-6 = t('.heading')
   = f.label :station_id, t('.station_label'), name: 'arrival[station_id]', class: 'pr-2'
-  = f.collection_select :station_id, Station.cache_all, :id, :name_i18n, {}, { class: 'rounded-lg', data: { action: 'input->introduction#changeStation' } }
+  = f.collection_select :station_id, Station.cache_all, :id, :name_i18n, {}, { class: 'rounded-lg border-gray-300', data: { action: 'input->introduction#changeStation' } }
   = image_tag 'yamanote-line.png', alt: t('.station_alt')
   p.text-sm.list-disc.text-left = t('.hint')
   .mt-4.flex.justify-end

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "@tailwindcss/forms": "^0.5.11",
         "caniuse-lite": "^1.0.30001632",
         "leaflet": "^1.9.4",
         "tailwindcss-stimulus-components": "^5.1.1"
@@ -159,17 +158,6 @@
       "dev": true,
       "peerDependencies": {
         "prettier": "^3.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/forms": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.11.tgz",
-      "integrity": "sha512-h9wegbZDPurxG22xZSoWtdzc41/OlNEUQERNqI/0fOwa2aVlWGu7C35E/x6LDyD3lgtztFSSjKZyuVM0hxhbgA==",
-      "dependencies": {
-        "mini-svg-data-uri": "^1.2.3"
-      },
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
       }
     },
     "node_modules/@types/json5": {
@@ -1957,14 +1945,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/mini-svg-data-uri": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
-      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
-      "bin": {
-        "mini-svg-data-uri": "cli.js"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2577,12 +2557,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "peer": true
     },
     "node_modules/tailwindcss-stimulus-components": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "fix": "prettier --write 'app/javascript/**/*.js'"
   },
   "dependencies": {
-    "@tailwindcss/forms": "^0.5.11",
     "caniuse-lite": "^1.0.30001632",
     "leaflet": "^1.9.4",
     "tailwindcss-stimulus-components": "^5.1.1"


### PR DESCRIPTION
## 概要

`@tailwindcss/forms` プラグインへの依存を除去し、同プラグインが提供していたフォームリセット CSS を明示化しました。

**依存を除去する目的**: `tailwindcss-rails` は Node.js を不要にすることを思想として gem にバイナリを同梱する設計になっています。しかし `@tailwindcss/forms` は npm パッケージであり、peer dependency として Node.js 経由の tailwindcss が引き込まれていたため、その思想と一致していませんでした。プラグインが暗黙的に提供していたスタイルを `@layer base` に明示化することで依存を除去し、Nodeless の方針に一貫させます。

## 変更内容

- `app/assets/tailwind/application.css`
  - `@plugin '@tailwindcss/forms'` を削除
  - プラグインが暗黙的に提供していたフォームリセット CSS（input/select/textarea/checkbox/radio のリセット、select の chevron アイコン、WebKit datetime 補正）を `@layer base` として明示化
  - v3→v4 の border 互換レイヤー（`* { border-color: gray-200 }`）を削除
- `package.json` / `package-lock.json`
  - `@tailwindcss/forms` および peer dependency の `tailwindcss` を削除
- `app/views/walks/new.html.slim`
  - `border-4` に `border-gray-200` を明示
- `app/views/walks/new/_page1.html.slim`
  - `collection_select` に `border-gray-300` を明示
- `app/views/walks/edit.html.slim`
  - `.toggle-switch` の `::after` 用に `[&::after]:border-gray-200` を明示

## テスト方法

- [x] Walk 作成ウィザード page1（select の chevron・境界線）
- [x] Walk 作成ウィザード page2（radio ボタンの色・選択状態）
- [x] Arrival 編集（time_select・textarea の境界線）
- [x] Walk 設定（toggle-switch の動作・URL コピー欄）
- [x] メモダイアログ（textarea の境界線）