### PR TITLE
GPS トラッキング機能の PoC

### DIFF
--- a/app/controllers/gps_points_controller.rb
+++ b/app/controllers/gps_points_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class GpsPointsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_walk
+
+  def create
+    gps_point = @walk.gps_points.build(gps_point_params)
+    if gps_point.save
+      head :created
+    else
+      head :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_walk
+    @walk = current_user.walks.find(params[:walk_id])
+  rescue ActiveRecord::RecordNotFound
+    head :not_found
+  end
+
+  def gps_point_params
+    params.require(:gps_point).permit(:latitude, :longitude, :recorded_at)
+  end
+end

--- a/app/controllers/walks_controller.rb
+++ b/app/controllers/walks_controller.rb
@@ -15,6 +15,10 @@ class WalksController < ApplicationController
     @station = @walk.current_station
     @arrived_distance = @walk.arrived_distance
     @number_of_walked = @walk.number_of_walked
+    if @walk.tracking?
+      @gps_points = @walk.gps_points.order(:recorded_at).pluck(:latitude, :longitude)
+      gon.gps_points = @gps_points
+    end
   end
 
   def edit; end
@@ -63,7 +67,7 @@ class WalksController < ApplicationController
   end
 
   def walk_params
-    params.require(:walk).permit(:clockwise, :publish)
+    params.require(:walk).permit(:clockwise, :publish, :tracking)
   end
 
   def arrival_params

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -25,9 +25,23 @@ export default class extends Controller {
     }
   }
 
+  disconnect() {
+    if (this._intervalId) {
+      clearInterval(this._intervalId);
+    }
+  }
+
   locate() {
     if (!navigator.geolocation) return;
 
+    if (!this._intervalId) {
+      this._intervalId = setInterval(() => this._fetchPosition(), 10000);
+    }
+
+    this._fetchPosition();
+  }
+
+  _fetchPosition() {
     navigator.geolocation.getCurrentPosition(
       (position) => {
         const { latitude, longitude } = position.coords;

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -8,6 +8,7 @@ export default class extends Controller {
     stations: Array,
     arrivedIds: Array,
     currentId: String,
+    tracking: { type: Boolean, default: false },
   };
 
   /* eslint-disable no-undef */
@@ -21,6 +22,34 @@ export default class extends Controller {
       this._addLine({ stations: this.allStations, color: "green" });
       this._addPins(this.allStations);
       this._addLine({ stations: this.arrivedStations, color: "red" });
+    }
+  }
+
+  locate() {
+    if (!navigator.geolocation) return;
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        const { latitude, longitude } = position.coords;
+        console.log("[map] locate:", { latitude, longitude });
+        this._updateCurrentLocationMarker(latitude, longitude);
+      },
+      () => {},
+      { enableHighAccuracy: true, timeout: 10000 },
+    );
+  }
+
+  _updateCurrentLocationMarker(latitude, longitude) {
+    if (this._currentLocationMarker) {
+      this._currentLocationMarker.setLatLng([latitude, longitude]);
+    } else {
+      this._currentLocationMarker = L.circleMarker([latitude, longitude], {
+        radius: 8,
+        color: "#1d4ed8",
+        fillColor: "#3b82f6",
+        fillOpacity: 1,
+        weight: 2,
+      }).addTo(map);
     }
   }
 

--- a/app/models/gps_point.rb
+++ b/app/models/gps_point.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class GpsPoint < ApplicationRecord
+  belongs_to :walk
+  validates :latitude, :longitude, :recorded_at, presence: true
+end

--- a/app/models/walk.rb
+++ b/app/models/walk.rb
@@ -4,6 +4,7 @@ class Walk < ApplicationRecord
   belongs_to :user
   has_many :arrivals, dependent: :destroy
   has_many :stations, through: :arrivals
+  has_many :gps_points, dependent: :destroy
   validates :clockwise, inclusion: { in: [true, false] }
   validate :active_walk_uniqueness, on: :create
 

--- a/app/views/shared/_map.html.slim
+++ b/app/views/shared/_map.html.slim
@@ -1,4 +1,10 @@
-div[data-controller='map' data-map-stations-value="#{Station.cache_all.to_json(methods: :name_i18n)}"
-                          data-map-arrived-ids-value="#{station_ids.to_json}"
-                          data-map-current-id-value="#{current_station.id}"]
+- tracking = defined?(walk) && walk&.tracking? && !walk&.finished?
+div[data-controller="map"
+    data-map-stations-value="#{Station.cache_all.to_json(methods: :name_i18n)}"
+    data-map-arrived-ids-value="#{station_ids.to_json}"
+    data-map-current-id-value="#{current_station.id}"
+    data-map-tracking-value="#{tracking}"]
   #map.w-full class='h-[440px] md:h-[500px]'
+  - if tracking
+    button.mt-2.px-3.py-1.text-sm.bg-blue-600.rounded[data-action="map#locate"]
+      = t('shared.map.locate_me')

--- a/app/views/walks/edit.html.slim
+++ b/app/views/walks/edit.html.slim
@@ -14,6 +14,14 @@
     p.text-xs.text-gray-500.mt-4
       = t('.public_hint')
 
+  .flex.items-center.mt-6
+    span.pr-2 #{@walk.tracking? ? t('.tracking_label') : t('.tracking_label')}
+    = form_with model: @walk, class: 'inline-block', method: :patch do |f|
+      = f.label :tracking
+        = f.check_box :tracking, { class: 'sr-only peer', onchange: 'this.form.requestSubmit()' }, 'true', 'false'
+        div class='toggle-switch cursor-pointer [&::after]:border-gray-200'
+  p.text-xs.text-gray-500.mt-1 = t('.tracking_hint')
+
   - if @walk.publish
     .flex.items-center.mt-4
       label.text-xs.pr-1 for='url' URL

--- a/app/views/walks/new/_page3.html.slim
+++ b/app/views/walks/new/_page3.html.slim
@@ -10,6 +10,11 @@
         td.font-semibold data-introduction-target='selectedClockwiseMode'
   = image_tag 'clockwise.png', alt: t('.guide_alt'), data: { clockwise_target: 'guide' }
   p.text-sm.list-disc.text-left = t('.hint')
+  .mt-4.flex.items-center.gap-2
+    = hidden_field_tag 'walk[tracking]', 'false'
+    = check_box_tag 'walk[tracking]', 'true', false, class: 'rounded border-gray-300', id: 'walk_tracking_new'
+    = label_tag 'walk_tracking_new', t('.tracking_label'), class: 'text-sm font-medium'
+  p.text-xs.text-gray-500 = t('.tracking_hint')
   .mt-4.flex.justify-between
     = link_to '#', data: { action: 'pagination#backStartPage' }, class: 'link-important'
       = t('.reconfigure')

--- a/app/views/walks/show.html.slim
+++ b/app/views/walks/show.html.slim
@@ -13,7 +13,7 @@ div data-controller='caution'
       = link_to t('.walk_again'), walk_deactivation_path(current_walk), data: { turbo_method: :post, turbo_confirm: t('.walk_again_confirm') }, class: 'mx-4 link-important'
 - else
   = render partial: 'walk', locals: { walk: @walk, arrival: @arrival, current_station: @station }
-= render partial: 'shared/map', locals: { current_station: @station, station_ids: @arrivals }
+= render partial: 'shared/map', locals: { current_station: @station, station_ids: @arrivals, walk: @walk, gps_points: (@gps_points || []) }
 .my-4.text-center
   h2.font-bold.mb-2 = t('.here_record')
   table.mb-4.mx-auto data-controller="time" data-time-departure-date-value="#{@walk.arrival_of_departure.arrived_at.iso8601}"

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -1,6 +1,8 @@
 ---
 en:
   shared:
+    map:
+      locate_me: Show my location
     buttons:
       edit: Edit
       delete: Delete

--- a/config/locales/views/shared/ja.yml
+++ b/config/locales/views/shared/ja.yml
@@ -1,6 +1,8 @@
 ---
 ja:
   shared:
+    map:
+      locate_me: 現在地を表示
     buttons:
       edit: 編集
       delete: 削除

--- a/config/locales/views/walks/en.yml
+++ b/config/locales/views/walks/en.yml
@@ -36,6 +36,8 @@ en:
       title: Walk record settings
       heading: Walk record settings
       public_hint: Turning on Public allows you to share the arrival history URL with others.
+      tracking_label: GPS Tracking
+      tracking_hint: "When ON, your walking route will be shown on the map (browser location permission required)."
     new:
       title: Walk settings
       welcome: Welcome to YamaNotes!
@@ -56,6 +58,8 @@ en:
         hint: The walking distance changes depending on whether you walk on the inside or outside of the tracks. Choose your route based on your fitness level.
         reconfigure: Change settings
         start: Start
+        tracking_label: GPS Tracking
+        tracking_hint: "When ON, your walking route will be shown on the map (browser location permission required)."
     walk:
       previous_station: "Previous station:"
       next_station: "Next station:"

--- a/config/locales/views/walks/ja.yml
+++ b/config/locales/views/walks/ja.yml
@@ -36,6 +36,8 @@ ja:
       title: 歩行記録設定
       heading: 歩行記録の設定
       public_hint: 公開をONにすると、到着履歴のURLを他の人とシェアできます。
+      tracking_label: GPS トラッキング
+      tracking_hint: ONにすると、歩いた経路が地図に表示されます（ブラウザの位置情報許可が必要）。
     new:
       title: 一周の設定
       welcome: YamaNotesへようこそ！
@@ -56,6 +58,8 @@ ja:
         hint: 線路の内側・外側のどちらを歩くかで、歩行距離が変わります。体力に応じてルートを決めてください。
         reconfigure: 設定し直す
         start: はじめる
+        tracking_label: GPS トラッキング
+        tracking_hint: ONにすると、歩いた経路が地図に表示されます（ブラウザの位置情報許可が必要）。
     walk:
       previous_station: "前の駅:"
       next_station: "次の駅:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 Rails.application.routes.draw do
   resources :walks do
     resource :deactivation, only: [:create], controller: 'walks/deactivations'
+    resources :gps_points, only: [:create]
     scope module: 'walk' do
       resources :arrivals, only: [:index]
     end

--- a/db/migrate/20260413104602_add_tracking_to_walks.rb
+++ b/db/migrate/20260413104602_add_tracking_to_walks.rb
@@ -1,0 +1,5 @@
+class AddTrackingToWalks < ActiveRecord::Migration[8.1]
+  def change
+    add_column :walks, :tracking, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260413104603_create_gps_points.rb
+++ b/db/migrate/20260413104603_create_gps_points.rb
@@ -1,0 +1,13 @@
+class CreateGpsPoints < ActiveRecord::Migration[8.1]
+  def change
+    create_table :gps_points do |t|
+      t.references :walk, null: false, foreign_key: true
+      t.float :latitude, null: false
+      t.float :longitude, null: false
+      t.datetime :recorded_at, null: false
+
+      t.timestamps
+    end
+    add_index :gps_points, [:walk_id, :recorded_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_022148) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_104603) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -24,6 +24,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_022148) do
     t.index ["created_at"], name: "index_arrivals_on_created_at"
     t.index ["station_id"], name: "index_arrivals_on_station_id"
     t.index ["walk_id"], name: "index_arrivals_on_walk_id"
+  end
+
+  create_table "gps_points", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.float "latitude", null: false
+    t.float "longitude", null: false
+    t.datetime "recorded_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "walk_id", null: false
+    t.index ["walk_id", "recorded_at"], name: "index_gps_points_on_walk_id_and_recorded_at"
+    t.index ["walk_id"], name: "index_gps_points_on_walk_id"
   end
 
   create_table "stations", force: :cascade do |t|
@@ -54,6 +65,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_022148) do
     t.boolean "clockwise", default: true, null: false
     t.datetime "created_at", null: false
     t.boolean "publish", default: false, null: false
+    t.boolean "tracking", default: false, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index ["user_id"], name: "index_walks_on_user_id", unique: true, where: "(active = true)"
@@ -61,5 +73,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_022148) do
 
   add_foreign_key "arrivals", "stations"
   add_foreign_key "arrivals", "walks"
+  add_foreign_key "gps_points", "walks"
   add_foreign_key "walks", "users"
 end


### PR DESCRIPTION
## 概要

Walk 中の GPS 座標を定期収集・保存し、歩いた経路を地図上に表示する GPS トラッキング機能の PoC。

## 変更内容

### DB
- `walks` テーブルに `tracking` カラム（boolean, default: false）を追加
- `gps_points` テーブルを新設（walk_id / latitude / longitude / recorded_at）

### バックエンド
- `GpsPoint` モデルを追加（`belongs_to :walk`）
- `Walk` モデルに `has_many :gps_points` を追加
- `POST /walks/:walk_id/gps_points` エンドポイントを追加（認証済みユーザーのみ）
- `WalksController#show` で `tracking: ON` の場合に GPS 座標を `gon` 経由でフロントに渡す

### フロントエンド
- `map_controller.js` にページロード直後から 30 秒間隔で位置情報を収集・送信するロジックを追加
- 保存済みの GPS 軌跡を青い polyline で描画（既存の赤いラインと併存）
- Walk の new（page3）と edit ページに tracking ON/OFF のトグルを追加

## テスト方法

1. `bin/dev` でサーバー起動
2. Walk 新規作成時に「GPS トラッキング」を ON にして開始
3. show ページでブラウザの位置情報許可ダイアログが表示されることを確認
4. DevTools → Network で `/gps_points` への POST が 30 秒ごとに飛ぶことを確認
5. DB に `gps_points` レコードが蓄積されることを確認
6. ページリロード後に青い軌跡線と赤い駅間ラインが両方表示されることを確認
7. `tracking: OFF` の Walk では青線・GPS 収集が行われないことを確認

## 備考

- Mac 実機では `kCLErrorLocationUnknown` が発生し位置情報取得に失敗することがある（GPS チップ非搭載のため）
- 開発環境での動作確認は Chrome DevTools の Sensors（位置情報エミュレーション）を使うと確実
- 本番・iPhone 実機では `enableHighAccuracy: false` を `true` に戻すことを検討する