### PR TITLE
Dependabot の patch/minor アップデートを自動マージするワークフローを追加する

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -1,0 +1,23 @@
+name: "dependabot auto merge"
+
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Auto merge patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

Dependabot が作成した PR を自動マージするための GitHub Actions ワークフローを追加する。

## 変更内容

- `.github/workflows/dependabot_auto_merge.yml` を新規追加
- `patch` / `minor` アップデートのみ自動マージ（`major` は手動確認）
- CI が通過したタイミングで自動的にマージ実行（`--auto` フラグ）
- 通常の merge commit を使用

## テスト方法

- Dependabot が patch/minor の PR を作成したときに、CI 通過後に自動マージされることを確認
- major アップデートの PR は自動マージされないことを確認