### PR TITLE
feat: Feature Flag を自前実装で追加する

### DIFF
--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class FeatureFlag < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+
+  def self.enabled?(name)
+    find_by(name: name)&.enabled? || false
+  end
+
+  def self.enable!(name)
+    find_or_create_by!(name: name).update!(enabled: true)
+  end
+
+  def self.disable!(name)
+    find_or_create_by!(name: name).update!(enabled: false)
+  end
+end

--- a/db/migrate/20260416092537_create_feature_flags.rb
+++ b/db/migrate/20260416092537_create_feature_flags.rb
@@ -1,0 +1,11 @@
+class CreateFeatureFlags < ActiveRecord::Migration[8.1]
+  def change
+    create_table :feature_flags do |t|
+      t.string :name, null: false
+      t.boolean :enabled, default: false, null: false
+
+      t.timestamps
+    end
+    add_index :feature_flags, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_092537) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -24,6 +24,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_000000) do
     t.index ["created_at"], name: "index_arrivals_on_created_at"
     t.index ["station_id"], name: "index_arrivals_on_station_id"
     t.index ["walk_id"], name: "index_arrivals_on_walk_id"
+  end
+
+  create_table "feature_flags", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "enabled", default: false, null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_feature_flags_on_name", unique: true
   end
 
   create_table "stations", force: :cascade do |t|

--- a/spec/models/feature_flag_spec.rb
+++ b/spec/models/feature_flag_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FeatureFlag, type: :model do
+  describe '.enabled?' do
+    context 'フラグが存在しない場合' do
+      it 'false を返すこと' do
+        expect(FeatureFlag.enabled?(:nonexistent)).to be false
+      end
+    end
+
+    context 'フラグが enabled: true の場合' do
+      before { FeatureFlag.create!(name: 'test_feature', enabled: true) }
+
+      it 'true を返すこと' do
+        expect(FeatureFlag.enabled?(:test_feature)).to be true
+      end
+    end
+
+    context 'フラグが enabled: false の場合' do
+      before { FeatureFlag.create!(name: 'test_feature', enabled: false) }
+
+      it 'false を返すこと' do
+        expect(FeatureFlag.enabled?(:test_feature)).to be false
+      end
+    end
+  end
+
+  describe '.enable!' do
+    context 'フラグが存在しない場合' do
+      it 'レコードを作成してフラグを有効にすること' do
+        FeatureFlag.enable!(:new_feature)
+        expect(FeatureFlag.enabled?(:new_feature)).to be true
+      end
+    end
+
+    context 'フラグが disabled の場合' do
+      before { FeatureFlag.create!(name: 'new_feature', enabled: false) }
+
+      it 'フラグを有効にすること' do
+        FeatureFlag.enable!(:new_feature)
+        expect(FeatureFlag.enabled?(:new_feature)).to be true
+      end
+    end
+  end
+
+  describe '.disable!' do
+    context 'フラグが存在しない場合' do
+      it 'レコードを作成してフラグを無効にすること' do
+        FeatureFlag.disable!(:new_feature)
+        expect(FeatureFlag.enabled?(:new_feature)).to be false
+      end
+    end
+
+    context 'フラグが enabled の場合' do
+      before { FeatureFlag.create!(name: 'new_feature', enabled: true) }
+
+      it 'フラグを無効にすること' do
+        FeatureFlag.disable!(:new_feature)
+        expect(FeatureFlag.enabled?(:new_feature)).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

新機能の段階的リリースを安全に行うため、Feature Flag の仕組みを導入した。

### gem を使わず自前実装した背景

Flipper などの gem は管理 UI やパーセンテージロールアウトなど多機能だが、このアプリの現時点のニーズ（手動でオン・オフを切り替えて段階的リリースする）には機能過剰。gem の依存を増やさずに済む最小限の自前実装が適切と判断した。

## 変更内容

- `FeatureFlag` モデルを追加（`feature_flags` テーブル）
  - `enabled?(name)` — フラグが有効かどうかを返す
  - `enable!(name)` — フラグを有効化する（レコードがなければ作成）
  - `disable!(name)` — フラグを無効化する（レコードがなければ作成）
- キャッシュなし。DB を直接参照するため `rails console` からの変更が即時反映される

## テスト方法

```bash
# マイグレーション
bundle exec rails db:migrate

# テスト
bundle exec rspec spec/models/feature_flag_spec.rb

# コンソールでの動作確認
rails console
FeatureFlag.enable!(:new_feature)   # => true
FeatureFlag.enabled?(:new_feature)  # => true
FeatureFlag.disable!(:new_feature)  # => true
FeatureFlag.enabled?(:new_feature)  # => false
```

## 使い方

```ruby
# コントローラー・ビューで利用する例
if FeatureFlag.enabled?(:new_ui)
  render 'new_ui'
end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)