### PR TITLE
i18n: モデルのバリデーションエラーメッセージを翻訳キーに移行し英語翻訳を追加する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,11 @@ config/locales/
     ├── dialogs/
     ├── layouts/
     ├── pages/
+    ├── public/
+    │   └── walks/
+    │       └── arrivals/
     ├── shared/      # 複数箇所で使うボタンラベルなど
+    ├── users/
     ├── walk/
     └── walks/
 ```

--- a/app/models/arrival.rb
+++ b/app/models/arrival.rb
@@ -22,8 +22,8 @@ class Arrival < ApplicationRecord
   private
 
   def check_arrived_time
-    errors.add :arrived_at, 'に未来の時刻は設定できません' if arrival_time_is_later_than_current?
-    errors.add :arrived_at, 'は、一つ前の到着時刻より後、一つ後ろの到着時間より前の時刻を設定してください' if arrival_time_is_outside_of_range?
+    errors.add :arrived_at, :cannot_be_future if arrival_time_is_later_than_current?
+    errors.add :arrived_at, :out_of_range if arrival_time_is_outside_of_range?
   end
 
   def arrival_time_is_later_than_current?
@@ -51,7 +51,7 @@ class Arrival < ApplicationRecord
       end
     return if is_correct_next_station
 
-    errors.add :station_id, '隣駅以外に到着することはできません'
+    errors.add :station_id, :must_be_adjacent_station
   end
 
   def convert_nil_to_blank
@@ -70,7 +70,7 @@ class Arrival < ApplicationRecord
   def check_arrival_location
     return if self == walk.arrivals.order(:created_at).last
 
-    errors.add :base, '最後の到着以外は削除できません'
+    errors.add :base, :only_last_arrival_can_be_deleted
     throw(:abort)
   end
 
@@ -79,7 +79,7 @@ class Arrival < ApplicationRecord
   end
 
   def arrivals_count_must_be_within_limit
-    errors.add(:base, '駅の数以上の到着記録は作成できません') if walk.arrivals.count > Station.cache_count
+    errors.add(:base, :arrivals_limit_exceeded) if walk.arrivals.count > Station.cache_count
   end
 
   def image_content_type_must_be_valid

--- a/app/models/walk.rb
+++ b/app/models/walk.rb
@@ -48,6 +48,6 @@ class Walk < ApplicationRecord
   def active_walk_uniqueness
     return unless user.walks.exists?(active: true)
 
-    errors.add(:user_id, '一人につき、実施中の歩行記録は一つしか作成できません')
+    errors.add(:user_id, :only_one_active_walk)
   end
 end

--- a/config/locales/models/arrival/en.yml
+++ b/config/locales/models/arrival/en.yml
@@ -10,3 +10,14 @@ en:
         station_id: Station
         walk_id: Walk log
         station: Station
+    errors:
+      models:
+        arrival:
+          attributes:
+            arrived_at:
+              cannot_be_future: cannot be in the future
+              out_of_range: must be after the previous arrival and before the next arrival
+            station_id:
+              must_be_adjacent_station: must be an adjacent station
+          only_last_arrival_can_be_deleted: only the last arrival can be deleted
+          arrivals_limit_exceeded: cannot exceed the total number of stations

--- a/config/locales/models/arrival/ja.yml
+++ b/config/locales/models/arrival/ja.yml
@@ -15,6 +15,13 @@ ja:
       models:
         arrival:
           attributes:
+            arrived_at:
+              cannot_be_future: に未来の時刻は設定できません
+              out_of_range: は、一つ前の到着時刻より後、一つ後ろの到着時間より前の時刻を設定してください
+            station_id:
+              must_be_adjacent_station: 隣駅以外に到着することはできません
             image:
               invalid_content_type: はPNGまたはJPEG形式のファイルを選択してください
               too_large: は5MB以下のファイルを選択してください
+          only_last_arrival_can_be_deleted: 最後の到着以外は削除できません
+          arrivals_limit_exceeded: 駅の数以上の到着記録は作成できません

--- a/config/locales/models/walk/en.yml
+++ b/config/locales/models/walk/en.yml
@@ -13,8 +13,11 @@ en:
         stations: Stations
         user_id: User
     errors:
-      messages:
-        restrict_multiple_creation: "Only one %{model} can be created"
+      models:
+        walk:
+          attributes:
+            user_id:
+              only_one_active_walk: "can only have one active walk at a time"
     success:
       messages:
         create: '%{model} was created'

--- a/config/locales/models/walk/ja.yml
+++ b/config/locales/models/walk/ja.yml
@@ -13,8 +13,11 @@ ja:
         stations: 駅
         user_id: ユーザ
     errors:
-      messages:
-        restrict_multiple_creation: "%{model}は1つしか作成できません"
+      models:
+        walk:
+          attributes:
+            user_id:
+              only_one_active_walk: "一人につき、実施中の歩行記録は一つしか作成できません"
     success:
       messages:
         create: '%{model}を作成しました'

--- a/spec/models/walk_spec.rb
+++ b/spec/models/walk_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Walk, type: :model do
 
       it 'invalid になること' do
         expect(walk).to be_invalid
-        expect(walk.errors).to be_added(:user_id, '一人につき、実施中の歩行記録は一つしか作成できません')
+        expect(walk.errors).to be_added(:user_id, :only_one_active_walk)
       end
     end
 


### PR DESCRIPTION
## 概要

モデルのバリデーションエラーメッセージがハードコードの日本語文字列になっており、英語ロケールで表示できない漏れを修正する。

## 変更内容

- `Arrival` モデルの4件のエラーメッセージを i18n キーに移行
  - `arrived_at` : `:cannot_be_future`、`:out_of_range`
  - `station_id` : `:must_be_adjacent_station`
  - `base` : `:only_last_arrival_can_be_deleted`、`:arrivals_limit_exceeded`
- `Walk` モデルの1件のエラーメッセージを i18n キーに移行
  - `user_id` : `:only_one_active_walk`（旧 `restrict_multiple_creation` キーを廃止）
- `config/locales/models/arrival/ja.yml` `en.yml` に翻訳を追加
- `config/locales/models/walk/ja.yml` `en.yml` の翻訳キーを整理
- `CLAUDE.md` の翻訳ファイル構造定義を実態（`views/users/`・`views/public/walks/arrivals/`）に合わせて更新

## テスト方法

```bash
bundle exec rspec spec/models/arrival_spec.rb spec/models/walk_spec.rb
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * エラーメッセージの表示体系を改善し、複数言語への対応を強化しました。

* **リファクタリング**
  * エラーメッセージ管理の内部構造を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->