### PR TITLE
feat: 到着画像の削除機能を追加する

### DIFF
--- a/app/controllers/arrivals/images_controller.rb
+++ b/app/controllers/arrivals/images_controller.rb
@@ -12,6 +12,11 @@ class Arrivals::ImagesController < ApplicationController
     end
   end
 
+  def destroy
+    @arrival.image.purge
+    redirect_to arrivals_path, notice: t('.purged')
+  end
+
   private
 
   def set_arrival

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -15,7 +15,12 @@
 
       - if FeatureFlag.enabled?(:image_upload)
         - if arrival.image.attached?
-          = image_tag arrival.image, class: 'mt-2 max-h-48 rounded', alt: t('.image_alt', station_name: arrival.station.name_i18n)
+          .relative.mt-2.inline-block
+            = image_tag arrival.image, class: 'max-h-48 rounded', alt: t('.image_alt', station_name: arrival.station.name_i18n)
+            = button_to arrival_image_path(arrival), method: :delete,
+                data: { turbo_confirm: t('.delete_image_confirm') },
+                form: { style: 'position:absolute; top:4px; right:4px;', data: { turbo_frame: '_top' } } do
+              i.fa-solid.fa-xmark.fa-2xl.text-gray-400
         - else
           = form_with url: arrival_image_path(arrival), method: :post, multipart: true do |f|
             = f.label :image, t('.attach_image'), class: 'text-sm link-important cursor-pointer'

--- a/config/locales/views/arrivals/en.yml
+++ b/config/locales/views/arrivals/en.yml
@@ -40,9 +40,12 @@ en:
       delete_confirm: Are you sure you want to delete?
       image_alt: "Image at %{station_name} station"
       attach_image: Add image
+      delete_image_confirm: Delete this image?
     images:
       create:
         attached: Image attached successfully.
+      destroy:
+        purged: Image deleted successfully.
     reports:
       show:
         arrived_message: "Arrived at %{station_name} station \U0001F389"

--- a/config/locales/views/arrivals/ja.yml
+++ b/config/locales/views/arrivals/ja.yml
@@ -40,9 +40,12 @@ ja:
       delete_confirm: 本当に削除しますか？
       image_alt: "%{station_name}の画像"
       attach_image: 画像を追加
+      delete_image_confirm: 画像を削除しますか？
     images:
       create:
         attached: 画像を追加しました。
+      destroy:
+        purged: 画像を削除しました。
     reports:
       show:
         arrived_message: "%{station_name}に到着しました\U0001F389"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   resources :arrivals, except: [:new] do
     scope module: 'arrivals' do
       resource :report, only: %i(show)
-      resource :image, only: %i(create)
+      resource :image, only: %i(create destroy)
     end
   end
 

--- a/spec/requests/arrivals/images_spec.rb
+++ b/spec/requests/arrivals/images_spec.rb
@@ -9,6 +9,32 @@ RSpec.describe 'Arrivals::Images', type: :request do
 
   before { sign_in login_user }
 
+  describe '#destroy' do
+    subject(:destroy_image) { delete arrival_image_path(arrival) }
+
+    before { arrival.image.attach(fixture_file_upload('spec/fixtures/files/sample.jpg', 'image/jpeg')) }
+
+    context '自分の到着記録の画像を削除する場合' do
+      let(:login_user) { walk_user }
+
+      it '画像が削除され、到着一覧にリダイレクトすること' do
+        destroy_image
+        expect(arrival.reload.image).not_to be_attached
+        expect(response).to redirect_to(arrivals_path)
+        expect(flash[:notice]).to eq('画像を削除しました。')
+      end
+    end
+
+    context '他のユーザーの到着記録の場合' do
+      let(:login_user) { FactoryBot.create(:user) }
+
+      it '404になること' do
+        destroy_image
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe '#create' do
     subject(:create_image) { post arrival_image_path(arrival), params: { image: } }
 


### PR DESCRIPTION
## 概要
到着記録の画像を削除できるようにする。

## 変更内容
- 画像右上に FontAwesome の × ボタン（`fa-xmark`）を表示
- `DELETE /arrivals/:arrival_id/image` ルートを追加
- `Arrivals::ImagesController#destroy` で `purge` して削除
- 削除確認ダイアログを表示（Turbo Confirm）
- ja/en 翻訳キーを追加（`delete_image_confirm`, `destroy.purged`）

## 注意
× ボタンの位置指定に `style` 属性を使用しており、UI の改善は別 PR で対応予定。

## テスト方法
- `image_upload` フィーチャーフラグを ON にする
  ```ruby
  FeatureFlag.enable!(:image_upload)
  ```
- 到着記録に画像をアップロードし、右上の × ボタンをクリック
- 確認ダイアログ → OK で画像が削除されアップロードフォームに戻ることを確認
- `bundle exec rspec spec/requests/arrivals/images_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 到着画像の削除機能を追加しました。ユーザーは削除ボタンをクリックして確認ダイアログを経て、画像を削除できます。削除完了時に成功メッセージが表示されます。日本語と英語による多言語対応を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->