### PR TITLE
feat: 本番環境で Cloudflare R2 を使った画像アップロードを有効にする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 ruby '4.0.2'
 
+gem 'aws-sdk-s3', require: false
 gem 'bootsnap', require: false
 gem 'devise'
 gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,25 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1240.0)
+    aws-sdk-core (3.245.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.123.0)
+      aws-sdk-core (~> 3, >= 3.244.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.219.0)
+      aws-sdk-core (~> 3, >= 3.244.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.22)
     bigdecimal (4.1.1)
@@ -181,6 +200,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     json (2.19.3)
     jwt (3.1.2)
       base64
@@ -541,6 +561,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  aws-sdk-s3
   bootsnap
   bullet
   capybara

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -15,6 +15,8 @@ Rails.application.configure do
   # Turn on fragment caching in view templates.
   config.action_controller.perform_caching = true
 
+  config.active_storage.service = :cloudflare
+
   # Cache assets for far-future expiry since they are all digest stamped.
   config.public_file_server.headers = { "cache-control" => "public, max-age=#{1.year.to_i}" }
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,10 +8,10 @@ local:
 
 cloudflare:
   service: S3
-  access_key_id: <%= ENV.fetch("CLOUDFLARE_R2_ACCESS_KEY_ID") %>
-  secret_access_key: <%= ENV.fetch("CLOUDFLARE_R2_SECRET_ACCESS_KEY") %>
-  endpoint: <%= ENV.fetch("CLOUDFLARE_R2_ENDPOINT") %>
-  bucket: <%= ENV.fetch("CLOUDFLARE_R2_BUCKET") %>
+  access_key_id: <%= ENV["CLOUDFLARE_R2_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["CLOUDFLARE_R2_SECRET_ACCESS_KEY"] %>
+  endpoint: <%= ENV["CLOUDFLARE_R2_ENDPOINT"] %>
+  bucket: <%= ENV["CLOUDFLARE_R2_BUCKET"] %>
   region: <%= ENV.fetch("CLOUDFLARE_R2_REGION", "auto") %>
   force_path_style: true
   request_checksum_calculation: when_required

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -5,3 +5,14 @@ test:
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
+
+cloudflare:
+  service: S3
+  access_key_id: <%= ENV["CLOUDFLARE_R2_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["CLOUDFLARE_R2_SECRET_ACCESS_KEY"] %>
+  endpoint: <%= ENV["CLOUDFLARE_R2_ENDPOINT"] %>
+  bucket: <%= ENV["CLOUDFLARE_R2_BUCKET"] %>
+  region: <%= ENV.fetch("CLOUDFLARE_R2_REGION", "auto") %>
+  force_path_style: true
+  request_checksum_calculation: when_required
+  response_checksum_validation: when_required

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,10 +8,10 @@ local:
 
 cloudflare:
   service: S3
-  access_key_id: <%= ENV["CLOUDFLARE_R2_ACCESS_KEY_ID"] %>
-  secret_access_key: <%= ENV["CLOUDFLARE_R2_SECRET_ACCESS_KEY"] %>
-  endpoint: <%= ENV["CLOUDFLARE_R2_ENDPOINT"] %>
-  bucket: <%= ENV["CLOUDFLARE_R2_BUCKET"] %>
+  access_key_id: <%= ENV.fetch("CLOUDFLARE_R2_ACCESS_KEY_ID") %>
+  secret_access_key: <%= ENV.fetch("CLOUDFLARE_R2_SECRET_ACCESS_KEY") %>
+  endpoint: <%= ENV.fetch("CLOUDFLARE_R2_ENDPOINT") %>
+  bucket: <%= ENV.fetch("CLOUDFLARE_R2_BUCKET") %>
   region: <%= ENV.fetch("CLOUDFLARE_R2_REGION", "auto") %>
   force_path_style: true
   request_checksum_calculation: when_required


### PR DESCRIPTION
## 概要

#303 で実装した画像アップロード機能を本番環境で使えるようにする。

## 変更内容

- `aws-sdk-s3` gem を追加（Cloudflare R2 は S3 互換 API のため必要）
- `config/storage.yml` に `cloudflare:` サービス定義を追加（認証情報は環境変数から読み込む）
- `config/environments/production.rb` で `config.active_storage.service = :cloudflare` を設定

## テスト方法

1. fly.io の環境変数に以下が設定されていることを確認する
   - `CLOUDFLARE_R2_ACCESS_KEY_ID`
   - `CLOUDFLARE_R2_SECRET_ACCESS_KEY`
   - `CLOUDFLARE_R2_ENDPOINT`
   - `CLOUDFLARE_R2_BUCKET`
2. デプロイ後、到着履歴ページで画像アップロードが正常に動作することを確認する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Cloudflare R2 を利用した外部ストレージをサポートしました（本番環境で有効）。

* **Chores**
  * 本番環境で外部ストレージを使用する設定を追加・更新しました。
  * 外部ストレージ接続に必要なライブラリを依存関係に追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->