### PR TITLE
fix: OAuth ログイン後に active な Walk がない場合の UrlGenerationError を修正

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -18,7 +18,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       session['devise.google_oauth2_data'] = request.env['omniauth.auth'].except(:extra)
     end
     set_flash_message(:notice, :success, kind: 'Google') if is_navigational_format?
-    redirect_to @user.walks.present? ? walk_path(current_walk) : new_walk_path
+    redirect_to current_walk ? walk_path(current_walk) : new_walk_path
   end
 
   def failure


### PR DESCRIPTION
## 概要

Google OAuth ログイン後、`active: false` な Walk しか持たないユーザーが `ActionController::UrlGenerationError` でクラッシュするバグを修正。

## 変更内容

`OmniauthCallbacksController#google_oauth2` のリダイレクト先判定を修正。

**Before:**
```ruby
redirect_to @user.walks.present? ? walk_path(current_walk) : new_walk_path
```

**After:**
```ruby
redirect_to current_walk ? walk_path(current_walk) : new_walk_path
```

`@user.walks.present?` は Walk レコードの存在チェックだが、`walk_path(current_walk)` は active な Walk を要求する。Walk が全て `active: false` の場合、`current_walk` が `nil` となり `walk_path(nil)` でエラーが発生していた。`current_walk` の nil チェックに統一することで解消。

## テスト方法

1. Walk を終了済み（`active: false`）の状態にする
2. ログアウトして Google OAuth で再ログイン
3. `new_walk_path` にリダイレクトされることを確認（500 エラーにならない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* Google OAuth2ログイン後のリダイレクト処理を改善しました。現在のセッション状態に基づいて、ユーザーがより適切なページに自動誘導されるようになります。これによりログイン後のユーザー体験が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->