### PR TITLE
feat: 画像アップロードUIを編集画面に移動

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -223,6 +223,27 @@
   }
 }
 
+@utility file-input {
+  @apply block w-full text-sm text-gray-500 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none;
+
+  &::file-selector-button {
+    margin-right: 1rem;
+    padding: 0.5rem 1rem;
+    border: 0;
+    border-right: 1px solid rgb(209 213 219);
+    border-radius: 0.5rem 0 0 0.5rem;
+    background-color: rgb(229 231 235);
+    color: rgb(55 65 81);
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  &::file-selector-button:hover {
+    background-color: rgb(209 213 219);
+  }
+}
+
 @layer components {
   dialog {
     @apply text-base-black mx-auto my-auto;

--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -27,12 +27,14 @@ class ArrivalsController < ApplicationController
   end
 
   def update
-    @arrival.assign_attributes(arrival_params)
-    return unless @arrival.changed?
+    @arrival.assign_attributes(arrival_params.except(:image))
+    @arrival.attach_image(arrival_params[:image]) if arrival_params[:image].present?
+    return unless @arrival.changed? || arrival_params[:image].present?
 
     if @arrival.save
       flash.now.notice = t('arrivals.update.updated')
     else
+      @arrival.image.purge if arrival_params[:image].present?
       render 'edit', status: :unprocessable_content
     end
   end
@@ -60,6 +62,6 @@ class ArrivalsController < ApplicationController
   end
 
   def arrival_params
-    params.require(:arrival).permit(:station_id, :arrived_at, :memo)
+    params.require(:arrival).permit(:station_id, :arrived_at, :memo, :image)
   end
 end

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -13,23 +13,18 @@
         p.text-xl
           | #{arrival.station.name_i18n}
 
-      - if FeatureFlag.enabled?(:image_upload)
-        - if arrival.image.attached?
-          .relative.mt-2.inline-block
-            = image_tag arrival.image, class: 'max-h-48 rounded', alt: t('.image_alt', station_name: arrival.station.name_i18n)
-            = button_to arrival_image_path(arrival), method: :delete,
-                data: { turbo_confirm: t('.delete_image_confirm') },
-                form: { style: 'position:absolute; top:4px; right:4px;', data: { turbo_frame: '_top' } } do
-              i.fa-solid.fa-xmark.fa-2xl.text-gray-400
-        - else
-          = form_with url: arrival_image_path(arrival), method: :post, multipart: true do |f|
-            = f.label :image, t('.attach_image'), class: 'text-sm link-important cursor-pointer'
-            = f.file_field :image, accept: 'image/png,image/jpeg', class: 'hidden', onchange: 'this.form.submit()'
-
       - if arrival.memo.present?
         #arrival_memo.text-sm.text-zinc-500.break-all.ml-1
           / XSSが起きないことを確認の上、slimlintから除外
           = raw Rinku.auto_link(simple_format(h(arrival.memo)), :all, 'target="_blank"')
+
+      - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
+        .relative.mt-2.inline-block
+          = image_tag arrival.image, class: 'max-h-48 rounded', alt: t('.image_alt', station_name: arrival.station.name_i18n)
+          = button_to arrival_image_path(arrival), method: :delete,
+              data: { turbo_confirm: t('.delete_image_confirm') },
+              form: { style: 'position:absolute; top:4px; right:4px;', data: { turbo_frame: '_top' } } do
+            i.fa-solid.fa-xmark.fa-2xl.text-gray-400
     = link_to edit_arrival_path(arrival), class: 'inline-block h-11 content-center' do
       .text-sm.h-8.link-important = t('shared.buttons.edit')
     - if deletable?(arrival:, arrivals:)

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -25,7 +25,7 @@
             = button_to arrival_image_path(arrival), method: :delete,
                 data: { turbo_confirm: t('.delete_image_confirm') },
                 form: { data: { turbo_frame: '_top' } },
-                class: 'flex items-center justify-center p-1 bg-white rounded-full' do
+                class: 'flex items-center justify-center p-1 bg-white bg-opacity-25 rounded' do
               i.fa-solid.fa-xmark.text-gray-400
     = link_to edit_arrival_path(arrival), class: 'inline-block h-11 content-center' do
       .text-sm.h-8.link-important = t('shared.buttons.edit')

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -21,10 +21,12 @@
       - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
         .relative.mt-2.inline-block
           = image_tag arrival.image, class: 'max-h-48 rounded', alt: t('.image_alt', station_name: arrival.station.name_i18n)
-          = button_to arrival_image_path(arrival), method: :delete,
-              data: { turbo_confirm: t('.delete_image_confirm') },
-              form: { style: 'position:absolute; top:4px; right:4px;', data: { turbo_frame: '_top' } } do
-            i.fa-solid.fa-xmark.fa-2xl.text-gray-400
+          div style='position:absolute; top:4px; right:4px;'
+            = button_to arrival_image_path(arrival), method: :delete,
+                data: { turbo_confirm: t('.delete_image_confirm') },
+                form: { data: { turbo_frame: '_top' } },
+                class: 'flex items-center justify-center p-1 bg-white rounded-full' do
+              i.fa-solid.fa-xmark.text-gray-400
     = link_to edit_arrival_path(arrival), class: 'inline-block h-11 content-center' do
       .text-sm.h-8.link-important = t('shared.buttons.edit')
     - if deletable?(arrival:, arrivals:)

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -29,8 +29,4 @@
               i.fa-solid.fa-xmark.text-gray-400
     = link_to edit_arrival_path(arrival), class: 'inline-block h-11 content-center' do
       .text-sm.h-8.link-important = t('shared.buttons.edit')
-    - if deletable?(arrival:, arrivals:)
-      = link_to t('shared.buttons.delete'), arrival,
-               class: 'text-sm text-gray-400 underline pl-4 hover:text-black',
-               data: { turbo_frame: 'arrivals-list', turbo_method: 'delete', turbo_confirm: t('.delete_confirm') }
 - # rubocop:enable Rails/OutputSafety

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -11,5 +11,5 @@
     - if FeatureFlag.enabled?(:image_upload) && !@arrival.image.attached?
       = f.label :image, t('activerecord.attributes.arrival.image'), class: 'inline-block mt-4 mb-1'
       = f.file_field :image, accept: 'image/png,image/jpeg', class: 'file-input'
-    .text-center.my-2
+    .text-center.my-8
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -9,8 +9,7 @@
     = f.label :memo, class: 'inline-block mt-4 mb-1'
     = f.text_area :memo, class: 'inline w-full rounded border border-gray-300', placeholder: t('.memo_placeholder'), maxlength: 250, autofocus: true
     - if FeatureFlag.enabled?(:image_upload) && !@arrival.image.attached?
-      .max-w-lg.mx-auto
-        = f.label :image, t('activerecord.attributes.arrival.image'), class: 'inline-block mt-4 mb-1'
-        = f.file_field :image, accept: 'image/png,image/jpeg', class: 'block w-full text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none'
+      = f.label :image, t('activerecord.attributes.arrival.image'), class: 'inline-block mt-4 mb-1'
+      = f.file_field :image, accept: 'image/png,image/jpeg', class: 'file-input'
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -1,6 +1,6 @@
 = turbo_frame_tag @arrival
   = render 'shared/errors', model: @arrival
-  = form_with model: @arrival, method: :put do |f|
+  = form_with model: @arrival, method: :put, multipart: true do |f|
     = f.label :arrived_at, class: 'inline-block mt-4 mb-1'
     .flex.items-center
       = f.time_select :arrived_at, {}, { class: 'rounded border border-gray-300' }
@@ -8,5 +8,9 @@
         | #{@arrival.station.name_i18n}
     = f.label :memo, class: 'inline-block mt-4 mb-1'
     = f.text_area :memo, class: 'inline w-full rounded border border-gray-300', placeholder: t('.memo_placeholder'), maxlength: 250, autofocus: true
+    - if FeatureFlag.enabled?(:image_upload) && !@arrival.image.attached?
+      .max-w-lg.mx-auto
+        = f.label :image, t('activerecord.attributes.arrival.image'), class: 'inline-block mt-4 mb-1'
+        = f.file_field :image, accept: 'image/png,image/jpeg', class: 'block w-full text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none'
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -1,5 +1,14 @@
 = turbo_frame_tag @arrival
   = render 'shared/errors', model: @arrival
+  - if FeatureFlag.enabled?(:image_upload) && @arrival.image.attached?
+    .relative.mt-4.inline-block
+      = image_tag @arrival.image, class: 'max-h-48 rounded', alt: t('arrivals.arrival.image_alt', station_name: @arrival.station.name_i18n)
+      div style='position:absolute; top:4px; right:4px;'
+        = button_to arrival_image_path(@arrival), method: :delete,
+            data: { turbo_confirm: t('arrivals.arrival.delete_image_confirm') },
+            form: { data: { turbo_frame: '_top' } },
+            class: 'flex items-center justify-center p-1 bg-white bg-opacity-25 rounded' do
+          i.fa-solid.fa-xmark.text-gray-400
   = form_with model: @arrival, method: :put, multipart: true do |f|
     = f.label :arrived_at, class: 'inline-block mt-4 mb-1'
     .flex.items-center


### PR DESCRIPTION
## 概要

画像アップロードのUIを一覧画面から編集画面に移動し、メモと画像を同時に保存できるようにした。

## 変更内容

- **編集画面** (`edit.html.slim`)：画像添付済みなら削除ボタン付きサムネイル、未添付なら file_field を表示。メモと画像を PUT フォームで同時保存できる
- **一覧画面** (`_arrival.html.slim`)：表示順をメモ→画像に変更。到着削除ボタンを削除し編集ボタンのみに変更
- **コントローラ** (`arrivals_controller.rb`)：`update` で `attach_image` を呼びリサイズ処理を維持。`arrival_params` に `:image` を追加
- **CSS** (`application.css`)：`file-input` カスタムクラスを追加

## テスト方法

- [ ] 編集画面で画像を選択し保存すると、画像が添付されること
- [ ] 編集画面で画像添付済みの場合、サムネイルと削除ボタンが表示されること
- [ ] 編集画面で画像なしで保存すると、メモのみ更新されること
- [ ] 一覧画面で編集ボタンのみ表示されること
- [ ] 一覧画面で添付済み画像の削除ボタンが表示され、削除できること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 到着情報に画像のアップロード・削除機能を追加（PNG/JPEG対応）
  * 編集画面で画像プレビューと削除ボタンを表示、画像未登録時はアップロード入力を表示

* **スタイル**
  * ファイル入力とアップロードボタンの見た目を改善（フル幅、境界、ボタンのホバー等）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->