### PR TITLE
feat: 画像アップロードを到着編集フォームに統合する

### DIFF
--- a/app/controllers/arrivals/images_controller.rb
+++ b/app/controllers/arrivals/images_controller.rb
@@ -3,15 +3,6 @@
 class Arrivals::ImagesController < ApplicationController
   before_action :set_arrival
 
-  def create
-    if @arrival.attach_image(params[:image])
-      redirect_to arrivals_path, notice: t('.attached')
-    else
-      @arrival.image.purge
-      redirect_to arrivals_path, alert: @arrival.errors.full_messages.to_sentence
-    end
-  end
-
   def destroy
     @arrival.image.purge
     redirect_to arrivals_path, notice: t('.purged')

--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -28,12 +28,7 @@ class ArrivalsController < ApplicationController
 
   def update
     @arrival.assign_attributes(arrival_params)
-
-    if arrival_params[:image] && !@arrival.attach_image(arrival_params[:image])
-      @arrival.image.purge
-      render 'edit', status: :unprocessable_content
-      return
-    end
+    @arrival.attach_image(arrival_params[:image]) if arrival_params[:image]
 
     if @arrival.save
       flash.now.notice = t('arrivals.update.updated')

--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -28,7 +28,12 @@ class ArrivalsController < ApplicationController
 
   def update
     @arrival.assign_attributes(arrival_params)
-    return unless @arrival.changed?
+
+    if arrival_params[:image] && !@arrival.attach_image(arrival_params[:image])
+      @arrival.image.purge
+      render 'edit', status: :unprocessable_content
+      return
+    end
 
     if @arrival.save
       flash.now.notice = t('arrivals.update.updated')
@@ -60,6 +65,6 @@ class ArrivalsController < ApplicationController
   end
 
   def arrival_params
-    params.require(:arrival).permit(:station_id, :arrived_at, :memo)
+    params.require(:arrival).permit(:station_id, :arrived_at, :memo, :image)
   end
 end

--- a/app/models/arrival/image.rb
+++ b/app/models/arrival/image.rb
@@ -17,7 +17,6 @@ module Arrival::Image
 
   def attach_image(uploaded_file)
     image.attach(resize_image(uploaded_file))
-    valid?
   end
 
   private

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -13,18 +13,13 @@
         p.text-xl
           | #{arrival.station.name_i18n}
 
-      - if FeatureFlag.enabled?(:image_upload)
-        - if arrival.image.attached?
-          .relative.mt-2.inline-block
-            = image_tag arrival.image, class: 'max-h-48 rounded', alt: t('.image_alt', station_name: arrival.station.name_i18n)
-            = button_to arrival_image_path(arrival), method: :delete,
-                data: { turbo_confirm: t('.delete_image_confirm') },
-                form: { style: 'position:absolute; top:4px; right:4px;', data: { turbo_frame: '_top' } } do
-              i.fa-solid.fa-xmark.fa-2xl.text-gray-400
-        - else
-          = form_with url: arrival_image_path(arrival), method: :post, multipart: true do |f|
-            = f.label :image, t('.attach_image'), class: 'text-sm link-important cursor-pointer'
-            = f.file_field :image, accept: 'image/png,image/jpeg', class: 'hidden', onchange: 'this.form.submit()'
+      - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
+        .relative.mt-2.inline-block
+          = image_tag arrival.image, class: 'max-h-48 rounded', alt: t('.image_alt', station_name: arrival.station.name_i18n)
+          = button_to arrival_image_path(arrival), method: :delete,
+              data: { turbo_confirm: t('.delete_image_confirm') },
+              form: { style: 'position:absolute; top:4px; right:4px;', data: { turbo_frame: '_top' } } do
+            i.fa-solid.fa-xmark.fa-2xl.text-gray-400
 
       - if arrival.memo.present?
         #arrival_memo.text-sm.text-zinc-500.break-all.ml-1

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -8,5 +8,7 @@
         | #{@arrival.station.name_i18n}
     = f.label :memo, class: 'inline-block mt-4 mb-1'
     = f.text_area :memo, class: 'inline w-full rounded border border-gray-300', placeholder: t('.memo_placeholder'), maxlength: 250, autofocus: true
+    - if FeatureFlag.enabled?(:image_upload)
+      = f.file_field :image, accept: 'image/png,image/jpeg'
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -9,6 +9,6 @@
     = f.label :memo, class: 'inline-block mt-4 mb-1'
     = f.text_area :memo, class: 'inline w-full rounded border border-gray-300', placeholder: t('.memo_placeholder'), maxlength: 250, autofocus: true
     - if FeatureFlag.enabled?(:image_upload)
-      = f.file_field :image, accept: 'image/png,image/jpeg'
+      = f.file_field :image
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/config/locales/views/arrivals/en.yml
+++ b/config/locales/views/arrivals/en.yml
@@ -39,11 +39,8 @@ en:
       goal_badge: Goal
       delete_confirm: Are you sure you want to delete?
       image_alt: "Image at %{station_name} station"
-      attach_image: Add image
       delete_image_confirm: Delete this image?
     images:
-      create:
-        attached: Image attached successfully.
       destroy:
         purged: Image deleted successfully.
     reports:

--- a/config/locales/views/arrivals/ja.yml
+++ b/config/locales/views/arrivals/ja.yml
@@ -39,11 +39,8 @@ ja:
       goal_badge: ゴール
       delete_confirm: 本当に削除しますか？
       image_alt: "%{station_name}の画像"
-      attach_image: 画像を追加
       delete_image_confirm: 画像を削除しますか？
     images:
-      create:
-        attached: 画像を追加しました。
       destroy:
         purged: 画像を削除しました。
     reports:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   resources :arrivals, except: [:new] do
     scope module: 'arrivals' do
       resource :report, only: %i(show)
-      resource :image, only: %i(create destroy)
+      resource :image, only: %i(destroy)
     end
   end
 

--- a/spec/models/arrival/image_spec.rb
+++ b/spec/models/arrival/image_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe Arrival::Image, type: :model do
       it 'WebP に変換・リサイズされて保存されること' do
         original_size = File.size(Rails.root.join('spec/fixtures/files/large.jpg'))
         arrival.attach_image(fixture_file_upload('large.jpg', 'image/jpeg'))
-        expect(arrival.image).to be_attached
         expect(arrival.image.blob.content_type).to eq 'image/webp'
         expect(arrival.image.blob.byte_size).to be < original_size
       end
@@ -64,7 +63,6 @@ RSpec.describe Arrival::Image, type: :model do
     context '400x400 以下の画像の場合' do
       it 'WebP に変換されて保存されること' do
         arrival.attach_image(fixture_file_upload('sample.jpg', 'image/jpeg'))
-        expect(arrival.image).to be_attached
         expect(arrival.image.blob.content_type).to eq 'image/webp'
       end
     end
@@ -72,13 +70,12 @@ RSpec.describe Arrival::Image, type: :model do
     context 'PNG 画像の場合' do
       it 'WebP に変換されて保存されること' do
         arrival.attach_image(fixture_file_upload('sample.png', 'image/png'))
-        expect(arrival.image).to be_attached
         expect(arrival.image.blob.content_type).to eq 'image/webp'
       end
     end
 
     context 'GIF 画像の場合' do
-      it 'リサイズせずそのまま添付し、バリデーションエラーになること' do
+      it 'バリデーションエラーになること' do
         arrival.attach_image(fixture_file_upload('sample.gif', 'image/gif'))
         expect(arrival).not_to be_valid
         expect(arrival.errors[:image].join).to include 'はPNGまたはJPEG形式のファイルを選択してください'

--- a/spec/requests/arrivals/images_spec.rb
+++ b/spec/requests/arrivals/images_spec.rb
@@ -35,43 +35,4 @@ RSpec.describe 'Arrivals::Images', type: :request do
     end
   end
 
-  describe '#create' do
-    subject(:create_image) { post arrival_image_path(arrival), params: { image: } }
-
-    context '画像を添付できる場合' do
-      let(:login_user) { walk_user }
-      let(:image) { fixture_file_upload('spec/fixtures/files/sample.jpg', 'image/jpeg') }
-
-      it '画像が添付され、到着一覧にリダイレクトすること' do
-        create_image
-        expect(arrival.reload.image).to be_attached
-        expect(response).to redirect_to(arrivals_path)
-        expect(flash[:notice]).to eq('画像を追加しました。')
-      end
-    end
-
-    context '画像を添付できない場合' do
-      context 'PNG/JPEG以外のファイルの場合' do
-        let(:login_user) { walk_user }
-        let(:image) { fixture_file_upload('spec/fixtures/files/sample.gif', 'image/gif') }
-
-        it '画像が添付されず、エラーメッセージとともに到着一覧にリダイレクトすること' do
-          create_image
-          expect(arrival.reload.image).not_to be_attached
-          expect(response).to redirect_to(arrivals_path)
-          expect(flash[:alert]).to include('画像はPNGまたはJPEG形式のファイルを選択してください')
-        end
-      end
-
-      context '他のユーザーの到着記録の場合' do
-        let(:login_user) { FactoryBot.create(:user) }
-        let(:image) { fixture_file_upload('spec/fixtures/files/sample.jpg', 'image/jpeg') }
-
-        it '404になること' do
-          create_image
-          expect(response).to have_http_status(:not_found)
-        end
-      end
-    end
-  end
 end

--- a/spec/requests/arrivals/images_spec.rb
+++ b/spec/requests/arrivals/images_spec.rb
@@ -34,5 +34,4 @@ RSpec.describe 'Arrivals::Images', type: :request do
       end
     end
   end
-
 end

--- a/spec/requests/arrivals_spec.rb
+++ b/spec/requests/arrivals_spec.rb
@@ -149,6 +149,31 @@ RSpec.describe 'Arrivals', type: :request do
           expect(response).to have_http_status(:unprocessable_content)
         end
       end
+
+      context '正しい画像の場合' do
+        let!(:arrival_params) do
+          { arrived_at: Time.current, memo: '更新済み', image: fixture_file_upload('spec/fixtures/files/sample.jpg', 'image/jpeg') }
+        end
+
+        it '画像が添付され、メモも更新されること' do
+          patch arrival_path(arrival), params: { arrival: arrival_params }
+          expect(arrival.reload.image).to be_attached
+          expect(arrival.reload.memo).to eq('更新済み')
+        end
+      end
+
+      context '不正な画像の場合' do
+        let!(:arrival_params) do
+          { arrived_at: Time.current, memo: '更新済み', image: fixture_file_upload('spec/fixtures/files/sample.gif', 'image/gif') }
+        end
+
+        it '画像が添付されず、編集画面が再描画されエラーメッセージが表示されること' do
+          patch arrival_path(arrival), params: { arrival: arrival_params }
+          expect(arrival.reload.image).not_to be_attached
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include('画像はPNGまたはJPEG形式のファイルを選択してください')
+        end
+      end
     end
 
     context 'ログイン中のユーザーが歩行中のユーザーでない場合' do


### PR DESCRIPTION
## 概要

画像アップロード機能を到着編集フォームに統合し、メモと画像を保存ボタンで同時に保存できるようにした。

## 変更内容

- 画像追加の `file_field` を到着一覧画面から編集フォーム（`edit.html.slim`）に移動
- `ArrivalsController#update` で `attach_image` を呼び出してリサイズ・添付処理を行うよう変更
- `arrival_params` に `:image` を追加
- `ImagesController#create` アクション・対応ルーティング・翻訳キーを削除（編集フォームに統合したため不要）
- `attach_image` の `valid?` 戻り値を削除し、`save` の結果で判定する形に整理

## テスト方法

- [x] 到着編集画面でメモのみ編集して保存できること
- [x] 到着編集画面で画像とメモを同時に保存できること（画像が WebP に変換されること）
- [x] PNG/JPEG 以外の画像を選択した場合にエラーメッセージが表示されること
- [ ] 一覧画面で添付済み画像の削除ができること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 到着の編集ページで画像をアップロードできるようになりました（機能フラグ有効時に表示）。
* **改善**
  * 編集画面で画像プレビューと削除ボタンは、機能フラグが有効かつ画像がある場合のみ表示されるようになりました。
* **変更**
  * 画像添付に関する一部の表示メッセージを整理しました（添付成功メッセージの文言を削除）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->