### PR TITLE
feat: 編集フォームで画像選択時にプレビューを表示する

### DIFF
--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "preview"]
+
+  show() {
+    const file = this.inputTarget.files[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      this.previewTarget.src = e.target.result
+      this.previewTarget.classList.remove("hidden")
+    }
+    reader.readAsDataURL(file)
+  }
+}

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -16,7 +16,7 @@
                   alt: t('.image_alt', station_name: @arrival.station.name_i18n),
                   data: { image_preview_target: 'preview' }
         - else
-          img.max-h-48.max-w-full.rounded.mt-2.hidden data-image-preview-target='preview' src=''
+          img.max-h-48.max-w-full.rounded.mt-2.hidden data-image-preview-target='preview' src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n)
         = f.file_field :image, class: 'mt-2', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -9,6 +9,14 @@
     = f.label :memo, class: 'inline-block mt-4 mb-1'
     = f.text_area :memo, class: 'inline w-full rounded border border-gray-300', placeholder: t('.memo_placeholder'), maxlength: 250, autofocus: true
     - if FeatureFlag.enabled?(:image_upload)
-      = f.file_field :image
+      div data-controller='image-preview'
+        - if @arrival.image.attachment&.persisted?
+          = image_tag @arrival.image,
+                  class: 'max-h-48 rounded mt-2',
+                  alt: t('.image_alt', station_name: @arrival.station.name_i18n),
+                  data: { image_preview_target: 'preview' }
+        - else
+          img.max-h-48.max-w-full.rounded.mt-2.hidden data-image-preview-target='preview' src=''
+        = f.file_field :image, class: 'mt-2', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/config/locales/views/arrivals/en.yml
+++ b/config/locales/views/arrivals/en.yml
@@ -16,6 +16,7 @@ en:
       back_to_map: Back to map
     edit:
       memo_placeholder: Getting tired! Jealous of cyclists ><
+      image_alt: "Image preview at %{station_name} station"
     create:
       no_walk: No walk record found.
       save_failed: Could not save the arrival record.

--- a/config/locales/views/arrivals/ja.yml
+++ b/config/locales/views/arrivals/ja.yml
@@ -16,6 +16,7 @@ ja:
       back_to_map: 地図に戻る
     edit:
       memo_placeholder: 辛くなってきた！自転車が羨ましい><
+      image_alt: "%{station_name}の画像プレビュー"
     create:
       no_walk: 歩行記録が存在しません。
       save_failed: 到着記録を保存できませんでした。


### PR DESCRIPTION
## 概要

編集フォームで画像ファイルを選択した際、保存前の状態でもプレビューが表示されるようにした。

## 変更内容

- `image_preview_controller.js` を新規追加（Stimulus コントローラー）
  - `FileReader` でファイルを Base64 に変換し、`preview` ターゲットの `src` に設定して表示
- `edit.html.slim` を更新
  - 保存済み画像がある場合は既存画像を表示、ない場合は `hidden` の空 `img` を配置
  - ファイル選択時に `change->image-preview#show` でプレビューを差し替え
  - バリデーションエラー後の再レンダリング時は `attachment.persisted?` で判定し、未保存の添付ファイルで `signed_id` エラーが出ないよう対応
  - プレビュー用 `img` に `max-h-48 max-w-full` を指定してリサイズ
- 翻訳ファイル（ja.yml / en.yml）に `edit.image_alt` キーを追加

## テスト方法

- [x] 画像未添付の到着記録の編集フォームで画像を選択 → プレビューが表示されること
- [x] 画像添付済みの到着記録の編集フォームで別の画像を選択 → プレビューが差し替わること
- [x] バリデーションエラーが発生する操作（メモを250文字超にするなど）後もエラーなく編集フォームが表示されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 画像アップロード時に、ファイル選択と同時にリアルタイムでプレビューを表示する機能を追加しました。

* **多言語対応**
  * 画像プレビュー用の代替テキストを英語と日本語で追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->