### PR TITLE
feat: 編集フォームの画像選択・削除UIを改善する

### DIFF
--- a/app/controllers/arrivals/images_controller.rb
+++ b/app/controllers/arrivals/images_controller.rb
@@ -5,7 +5,7 @@ class Arrivals::ImagesController < ApplicationController
 
   def destroy
     @arrival.image.purge
-    redirect_to arrivals_path, notice: t('.purged')
+    redirect_to edit_arrival_path(@arrival)
   end
 
   private

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -17,8 +17,7 @@ export default class extends Controller {
     reader.readAsDataURL(file)
   }
 
-  cancel(event) {
-    event.preventDefault()
+  cancel() {
     this.inputTarget.value = ""
     this.previewTarget.src = ""
     this.previewTarget.classList.add("hidden")

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["input", "preview"]
+  static targets = ["input", "preview", "addButton"]
 
   show() {
     const file = this.inputTarget.files[0]
@@ -11,6 +11,9 @@ export default class extends Controller {
     reader.onload = (e) => {
       this.previewTarget.src = e.target.result
       this.previewTarget.classList.remove("hidden")
+      if (this.hasAddButtonTarget) {
+        this.addButtonTarget.classList.add("hidden")
+      }
     }
     reader.readAsDataURL(file)
   }

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["input", "preview", "addButton"]
+  static targets = ["input", "preview", "addButton", "cancelButton"]
 
   show() {
     const file = this.inputTarget.files[0]
@@ -14,7 +14,21 @@ export default class extends Controller {
       if (this.hasAddButtonTarget) {
         this.addButtonTarget.classList.add("hidden")
       }
+      if (this.hasCancelButtonTarget) {
+        this.cancelButtonTarget.classList.remove("hidden")
+      }
     }
     reader.readAsDataURL(file)
+  }
+
+  cancel(event) {
+    event.preventDefault()
+    this.inputTarget.value = ""
+    this.previewTarget.src = ""
+    this.previewTarget.classList.add("hidden")
+    if (this.hasAddButtonTarget) {
+      this.addButtonTarget.classList.remove("hidden")
+    }
+    this.cancelButtonTarget.classList.add("hidden")
   }
 }

--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -11,12 +11,8 @@ export default class extends Controller {
     reader.onload = (e) => {
       this.previewTarget.src = e.target.result
       this.previewTarget.classList.remove("hidden")
-      if (this.hasAddButtonTarget) {
-        this.addButtonTarget.classList.add("hidden")
-      }
-      if (this.hasCancelButtonTarget) {
-        this.cancelButtonTarget.classList.remove("hidden")
-      }
+      this.addButtonTarget.classList.add("hidden")
+      this.cancelButtonTarget.classList.remove("hidden")
     }
     reader.readAsDataURL(file)
   }
@@ -26,9 +22,7 @@ export default class extends Controller {
     this.inputTarget.value = ""
     this.previewTarget.src = ""
     this.previewTarget.classList.add("hidden")
-    if (this.hasAddButtonTarget) {
-      this.addButtonTarget.classList.remove("hidden")
-    }
+    this.addButtonTarget.classList.remove("hidden")
     this.cancelButtonTarget.classList.add("hidden")
   }
 }

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -14,12 +14,7 @@
           | #{arrival.station.name_i18n}
 
       - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
-        .relative.mt-2.inline-block
-          = image_tag arrival.image, class: 'max-h-48 rounded', alt: t('.image_alt', station_name: arrival.station.name_i18n)
-          = button_to arrival_image_path(arrival), method: :delete,
-              data: { turbo_confirm: t('.delete_image_confirm') },
-              form: { style: 'position:absolute; top:4px; right:4px;', data: { turbo_frame: '_top' } } do
-            i.fa-solid.fa-xmark.fa-2xl.text-gray-400
+        = image_tag arrival.image, class: 'max-h-48 rounded mt-2', alt: t('.image_alt', station_name: arrival.station.name_i18n)
 
       - if arrival.memo.present?
         #arrival_memo.text-sm.text-zinc-500.break-all.ml-1

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -22,8 +22,7 @@
           img.max-h-48.max-w-full.rounded.mt-2.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
           label.cursor-pointer.link-important.mt-2 for='arrival_image' data-image-preview-target='addButton'
             = t('.add_image')
-          a.block.text-sm.text-gray-400.underline.mt-1.hover:text-black.hidden data-image-preview-target='cancelButton' data-action='click->image-preview#cancel'
-            = t('.cancel_image')
+          = button_tag t('.cancel_image'), type: 'button', class: 'block text-sm text-gray-400 underline mt-1 hover:text-black hidden', data: { image_preview_target: 'cancelButton', action: 'click->image-preview#cancel' }
           = f.file_field :image, class: 'hidden', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -19,7 +19,7 @@
                       data: { image_preview_target: 'preview' }
             = link_to arrival_image_path(@arrival),
                 class: 'absolute top-1 right-1',
-                data: { turbo_method: :delete, turbo_confirm: t('.delete_image_confirm'), turbo_frame: '_top' } do
+                data: { turbo_method: :delete, turbo_confirm: t('.delete_image_confirm') } do
               i.fa-solid.fa-xmark.fa-2xl.text-gray-400
           img.max-h-48.max-w-full.rounded.mt-2.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
         - else

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -10,17 +10,22 @@
     = f.text_area :memo, class: 'inline w-full rounded border border-gray-300', placeholder: t('.memo_placeholder'), maxlength: 250, autofocus: true
     - if FeatureFlag.enabled?(:image_upload)
       div data-controller='image-preview'
-        = f.label :image, class: 'cursor-pointer' do
-          - if @arrival.image.attachment&.persisted?
-            = image_tag @arrival.image,
-                    class: 'max-h-48 rounded mt-2',
-                    alt: t('.image_alt', station_name: @arrival.station.name_i18n),
-                    data: { image_preview_target: 'preview' }
-          - else
-            img.max-h-48.max-w-full.rounded.mt-2.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
-          = f.file_field :image, class: 'hidden', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
-        - unless @arrival.image.attachment&.persisted?
+        - if @arrival.image.attachment&.persisted?
+          .relative.inline-block.mt-2
+            label.cursor-pointer for='arrival_image'
+              = image_tag @arrival.image,
+                      class: 'max-h-48 rounded',
+                      alt: t('.image_alt', station_name: @arrival.station.name_i18n),
+                      data: { image_preview_target: 'preview' }
+            = link_to arrival_image_path(@arrival),
+                class: 'absolute top-1 right-1',
+                data: { turbo_method: :delete, turbo_confirm: t('.delete_image_confirm'), turbo_frame: '_top' } do
+              i.fa-solid.fa-xmark.fa-2xl.text-gray-400
+          img.max-h-48.max-w-full.rounded.mt-2.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
+        - else
+          img.max-h-48.max-w-full.rounded.mt-2.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
           label.cursor-pointer.link-important.mt-2 for='arrival_image' data-image-preview-target='addButton'
             = t('.add_image')
+        = f.file_field :image, class: 'hidden', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -9,23 +9,21 @@
     = f.label :memo, class: 'inline-block mt-4 mb-1'
     = f.text_area :memo, class: 'inline w-full rounded border border-gray-300', placeholder: t('.memo_placeholder'), maxlength: 250, autofocus: true
     - if FeatureFlag.enabled?(:image_upload)
-      div data-controller='image-preview'
-        - if @arrival.image.attachment&.persisted?
-          .relative.inline-block.mt-2
-            label.cursor-pointer for='arrival_image'
-              = image_tag @arrival.image,
-                      class: 'max-h-48 rounded',
-                      alt: t('.image_alt', station_name: @arrival.station.name_i18n),
-                      data: { image_preview_target: 'preview' }
-            = link_to arrival_image_path(@arrival),
-                class: 'absolute top-1 right-1',
-                data: { turbo_method: :delete, turbo_confirm: t('.delete_image_confirm') } do
-              i.fa-solid.fa-xmark.fa-2xl.text-gray-400
-          img.max-h-48.max-w-full.rounded.mt-2.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
-        - else
+      - if @arrival.image.attachment&.persisted?
+        = image_tag @arrival.image,
+                class: 'max-h-48 rounded mt-2',
+                alt: t('.image_alt', station_name: @arrival.station.name_i18n)
+        = link_to arrival_image_path(@arrival),
+            class: 'block text-sm text-gray-400 underline mt-1 hover:text-black',
+            data: { turbo_method: :delete, turbo_confirm: t('.delete_image_confirm') }
+          = t('.delete_image')
+      - else
+        div data-controller='image-preview'
           img.max-h-48.max-w-full.rounded.mt-2.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
           label.cursor-pointer.link-important.mt-2 for='arrival_image' data-image-preview-target='addButton'
             = t('.add_image')
-        = f.file_field :image, class: 'hidden', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
+          a.block.text-sm.text-gray-400.underline.mt-1.hover:text-black.hidden data-image-preview-target='cancelButton' data-action='click->image-preview#cancel'
+            = t('.cancel_image')
+          = f.file_field :image, class: 'hidden', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -10,13 +10,17 @@
     = f.text_area :memo, class: 'inline w-full rounded border border-gray-300', placeholder: t('.memo_placeholder'), maxlength: 250, autofocus: true
     - if FeatureFlag.enabled?(:image_upload)
       div data-controller='image-preview'
-        - if @arrival.image.attachment&.persisted?
-          = image_tag @arrival.image,
-                  class: 'max-h-48 rounded mt-2',
-                  alt: t('.image_alt', station_name: @arrival.station.name_i18n),
-                  data: { image_preview_target: 'preview' }
-        - else
-          img.max-h-48.max-w-full.rounded.mt-2.hidden data-image-preview-target='preview' src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n)
-        = f.file_field :image, class: 'mt-2', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
+        = f.label :image, class: 'cursor-pointer' do
+          - if @arrival.image.attachment&.persisted?
+            = image_tag @arrival.image,
+                    class: 'max-h-48 rounded mt-2',
+                    alt: t('.image_alt', station_name: @arrival.station.name_i18n),
+                    data: { image_preview_target: 'preview' }
+          - else
+            img.max-h-48.max-w-full.rounded.mt-2.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
+          = f.file_field :image, class: 'hidden', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
+        - unless @arrival.image.attachment&.persisted?
+          label.cursor-pointer.link-important.mt-2 for='arrival_image' data-image-preview-target='addButton'
+            = t('.add_image')
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/config/locales/views/arrivals/en.yml
+++ b/config/locales/views/arrivals/en.yml
@@ -17,6 +17,7 @@ en:
     edit:
       memo_placeholder: Getting tired! Jealous of cyclists ><
       image_alt: "Image preview at %{station_name} station"
+      add_image: Add image
     create:
       no_walk: No walk record found.
       save_failed: Could not save the arrival record.

--- a/config/locales/views/arrivals/en.yml
+++ b/config/locales/views/arrivals/en.yml
@@ -18,6 +18,8 @@ en:
       memo_placeholder: Getting tired! Jealous of cyclists ><
       image_alt: "Image preview at %{station_name} station"
       add_image: Add image
+      delete_image: Delete image
+      cancel_image: Deselect image
       delete_image_confirm: Delete this image?
     create:
       no_walk: No walk record found.

--- a/config/locales/views/arrivals/en.yml
+++ b/config/locales/views/arrivals/en.yml
@@ -18,6 +18,7 @@ en:
       memo_placeholder: Getting tired! Jealous of cyclists ><
       image_alt: "Image preview at %{station_name} station"
       add_image: Add image
+      delete_image_confirm: Delete this image?
     create:
       no_walk: No walk record found.
       save_failed: Could not save the arrival record.
@@ -41,10 +42,7 @@ en:
       goal_badge: Goal
       delete_confirm: Are you sure you want to delete?
       image_alt: "Image at %{station_name} station"
-      delete_image_confirm: Delete this image?
-    images:
-      destroy:
-        purged: Image deleted successfully.
+
     reports:
       show:
         arrived_message: "Arrived at %{station_name} station \U0001F389"

--- a/config/locales/views/arrivals/ja.yml
+++ b/config/locales/views/arrivals/ja.yml
@@ -18,6 +18,8 @@ ja:
       memo_placeholder: 辛くなってきた！自転車が羨ましい><
       image_alt: "%{station_name}の画像プレビュー"
       add_image: 画像を追加
+      delete_image: 画像を削除
+      cancel_image: 画像の選択を解除
       delete_image_confirm: 画像を削除しますか？
     create:
       no_walk: 歩行記録が存在しません。

--- a/config/locales/views/arrivals/ja.yml
+++ b/config/locales/views/arrivals/ja.yml
@@ -17,6 +17,7 @@ ja:
     edit:
       memo_placeholder: 辛くなってきた！自転車が羨ましい><
       image_alt: "%{station_name}の画像プレビュー"
+      add_image: 画像を追加
     create:
       no_walk: 歩行記録が存在しません。
       save_failed: 到着記録を保存できませんでした。

--- a/config/locales/views/arrivals/ja.yml
+++ b/config/locales/views/arrivals/ja.yml
@@ -18,6 +18,7 @@ ja:
       memo_placeholder: 辛くなってきた！自転車が羨ましい><
       image_alt: "%{station_name}の画像プレビュー"
       add_image: 画像を追加
+      delete_image_confirm: 画像を削除しますか？
     create:
       no_walk: 歩行記録が存在しません。
       save_failed: 到着記録を保存できませんでした。
@@ -41,10 +42,7 @@ ja:
       goal_badge: ゴール
       delete_confirm: 本当に削除しますか？
       image_alt: "%{station_name}の画像"
-      delete_image_confirm: 画像を削除しますか？
-    images:
-      destroy:
-        purged: 画像を削除しました。
+
     reports:
       show:
         arrived_message: "%{station_name}に到着しました\U0001F389"

--- a/spec/requests/arrivals/images_spec.rb
+++ b/spec/requests/arrivals/images_spec.rb
@@ -17,11 +17,10 @@ RSpec.describe 'Arrivals::Images', type: :request do
     context '自分の到着記録の画像を削除する場合' do
       let(:login_user) { walk_user }
 
-      it '画像が削除され、到着一覧にリダイレクトすること' do
+      it '画像が削除され、編集フォームにリダイレクトすること' do
         destroy_image
         expect(arrival.reload.image).not_to be_attached
-        expect(response).to redirect_to(arrivals_path)
-        expect(flash[:notice]).to eq('画像を削除しました。')
+        expect(response).to redirect_to(edit_arrival_path(arrival))
       end
     end
 


### PR DESCRIPTION
## 概要

編集フォームの画像アップロードUIを改善しました。

## 変更内容

- 画像未選択時は「画像を追加」ボタンを表示し、クリックでファイル選択ダイアログを開く
- 画像選択後はプレビューと「画像の選択を解除」リンクを表示し、未保存の選択をキャンセルできる
- 保存済み画像は差し替えをなくし、「画像を削除」リンクで削除のみできるようにする
- 画像削除後は編集フォームを再レンダーする（`edit` にリダイレクト）
- 画像削除ボタンを一覧画面から非表示にし、編集フォームのみに表示する

## テスト方法

- [x] 編集フォームを開き「画像を追加」ボタンが表示されることを確認
- [x] 画像を選択するとプレビューと「画像の選択を解除」が表示されることを確認
- [x] 「画像の選択を解除」をクリックするとプレビューが消え「画像を追加」に戻ることを確認
- [x] 画像保存済みの場合、「画像を削除」リンクが表示されることを確認
- [x] 「画像を削除」で画像を削除後、編集フォームが再表示されることを確認
- [x] 一覧画面に画像削除ボタンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 画像プレビューに「キャンセル」ボタンを追加し、アップロード前の画像選択をキャンセル可能に

* **改善**
  * 画像削除後のリダイレクト先を到着情報編集ページに変更
  * 到着情報一覧ページの画像表示をシンプル化

* **多言語対応**
  * 画像アップロード/削除関連のテキストを日本語を含む多言語に対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->