### PR TITLE
feat: 画像削除・選択解除UIをバツボタンに変更し表示を改善する

### DIFF
--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -11,8 +11,8 @@ export default class extends Controller {
     reader.onload = (e) => {
       this.previewTarget.src = e.target.result
       this.previewTarget.classList.remove("hidden")
-      this.addButtonTarget.classList.add("hidden")
       this.cancelButtonTarget.classList.remove("hidden")
+      this.addButtonTarget.classList.add("hidden")
     }
     reader.readAsDataURL(file)
   }
@@ -21,7 +21,7 @@ export default class extends Controller {
     this.inputTarget.value = ""
     this.previewTarget.src = ""
     this.previewTarget.classList.add("hidden")
-    this.addButtonTarget.classList.remove("hidden")
     this.cancelButtonTarget.classList.add("hidden")
+    this.addButtonTarget.classList.remove("hidden")
   }
 }

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -19,7 +19,7 @@
           = raw Rinku.auto_link(simple_format(h(arrival.memo)), :all, 'target="_blank"')
 
       - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
-        = image_tag arrival.image.variant(resize_to_limit: [240, 400]), class: 'rounded mt-2', alt: t('.image_alt', station_name: arrival.station.name_i18n)
+        = image_tag arrival.image.variant(resize_to_limit: [280, 400]), class: 'rounded mt-2', alt: t('.image_alt', station_name: arrival.station.name_i18n)
     = link_to edit_arrival_path(arrival), class: 'inline-block h-11 content-center' do
       .text-sm.h-8.link-important = t('shared.buttons.edit')
     - if deletable?(arrival:, arrivals:)

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -19,7 +19,7 @@
           = raw Rinku.auto_link(simple_format(h(arrival.memo)), :all, 'target="_blank"')
 
       - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
-        = image_tag arrival.image, class: 'max-h-48 rounded mt-2', alt: t('.image_alt', station_name: arrival.station.name_i18n)
+        = image_tag arrival.image.variant(resize_to_limit: [240, nil]), class: 'rounded mt-2', alt: t('.image_alt', station_name: arrival.station.name_i18n)
     = link_to edit_arrival_path(arrival), class: 'inline-block h-11 content-center' do
       .text-sm.h-8.link-important = t('shared.buttons.edit')
     - if deletable?(arrival:, arrivals:)

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -13,13 +13,13 @@
         p.text-xl
           | #{arrival.station.name_i18n}
 
-      - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
-        = image_tag arrival.image, class: 'max-h-48 rounded mt-2', alt: t('.image_alt', station_name: arrival.station.name_i18n)
-
       - if arrival.memo.present?
         #arrival_memo.text-sm.text-zinc-500.break-all.ml-1
           / XSSが起きないことを確認の上、slimlintから除外
           = raw Rinku.auto_link(simple_format(h(arrival.memo)), :all, 'target="_blank"')
+
+      - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
+        = image_tag arrival.image, class: 'max-h-48 rounded mt-2', alt: t('.image_alt', station_name: arrival.station.name_i18n)
     = link_to edit_arrival_path(arrival), class: 'inline-block h-11 content-center' do
       .text-sm.h-8.link-important = t('shared.buttons.edit')
     - if deletable?(arrival:, arrivals:)

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -19,7 +19,7 @@
           = raw Rinku.auto_link(simple_format(h(arrival.memo)), :all, 'target="_blank"')
 
       - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
-        = image_tag arrival.image.variant(resize_to_limit: [240, nil]), class: 'rounded mt-2', alt: t('.image_alt', station_name: arrival.station.name_i18n)
+        = image_tag arrival.image.variant(resize_to_limit: [240, 400]), class: 'rounded mt-2', alt: t('.image_alt', station_name: arrival.station.name_i18n)
     = link_to edit_arrival_path(arrival), class: 'inline-block h-11 content-center' do
       .text-sm.h-8.link-important = t('shared.buttons.edit')
     - if deletable?(arrival:, arrivals:)

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -10,8 +10,8 @@
     = f.text_area :memo, class: 'inline w-full rounded border border-gray-300', placeholder: t('.memo_placeholder'), maxlength: 250, autofocus: true
     - if FeatureFlag.enabled?(:image_upload)
       - if @arrival.image.attachment&.persisted?
-        .flex.justify-center.mt-2
-          .relative.inline-block
+        .flex.justify-center
+          .relative.inline-block.my-4
             = image_tag @arrival.image.variant(resize_to_limit: [240, 400]),
                     class: 'rounded',
                     alt: t('.image_alt', station_name: @arrival.station.name_i18n)
@@ -25,7 +25,7 @@
         div data-controller='image-preview'
           .flex.justify-center
             .relative.inline-block
-              img.rounded.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='240' height='400' data-image-preview-target='preview'
+              img.rounded.my-4.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='240' height='400' data-image-preview-target='preview'
               div style='position:absolute; top:4px; right:4px;'
                 = button_tag type: 'button',
                     class: 'flex items-center justify-center p-1 bg-gray-50 rounded hidden',
@@ -34,6 +34,6 @@
                   i.fa-solid.fa-xmark.text-base-black
           label.cursor-pointer.text-sm.text-gray-400.underline.hover:text-black for='arrival_image' data-image-preview-target='addButton'
             = t('.add_image')
-          = f.file_field :image, class: 'hidden', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
+          = f.file_field :image, class: 'hidden', accept: 'image/png,image/jpeg', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -16,20 +16,20 @@
                   alt: t('.image_alt', station_name: @arrival.station.name_i18n)
           div style='position:absolute; top:4px; right:4px;'
             = link_to arrival_image_path(@arrival),
-                class: 'flex items-center justify-center p-1 bg-white bg-opacity-25 rounded',
+                class: 'flex items-center justify-center p-1 bg-gray-50 rounded',
                 aria: { label: t('.delete_image') },
                 data: { turbo_method: :delete, turbo_confirm: t('.delete_image_confirm') }
-              i.fa-solid.fa-xmark.text-gray-400
+              i.fa-solid.fa-xmark.text-base-black
       - else
         div data-controller='image-preview'
           .relative.inline-block.mt-2
             img.max-h-48.max-w-full.rounded.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
             div style='position:absolute; top:4px; right:4px;'
               = button_tag type: 'button',
-                  class: 'flex items-center justify-center p-1 bg-white bg-opacity-25 rounded hidden',
+                  class: 'flex items-center justify-center p-1 bg-gray-50 rounded hidden',
                   aria: { label: t('.cancel_image') },
                   data: { image_preview_target: 'cancelButton', action: 'click->image-preview#cancel' }
-                i.fa-solid.fa-xmark.text-gray-400
+                i.fa-solid.fa-xmark.text-base-black
           label.cursor-pointer.link-important.mt-2 for='arrival_image' data-image-preview-target='addButton'
             = t('.add_image')
           = f.file_field :image, class: 'hidden', data: { image_preview_target: 'input', action: 'change->image-preview#show' }

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -10,19 +10,28 @@
     = f.text_area :memo, class: 'inline w-full rounded border border-gray-300', placeholder: t('.memo_placeholder'), maxlength: 250, autofocus: true
     - if FeatureFlag.enabled?(:image_upload)
       - if @arrival.image.attachment&.persisted?
-        = image_tag @arrival.image,
-                class: 'max-h-48 rounded mt-2',
-                alt: t('.image_alt', station_name: @arrival.station.name_i18n)
-        = link_to arrival_image_path(@arrival),
-            class: 'block text-sm text-gray-400 underline mt-1 hover:text-black',
-            data: { turbo_method: :delete, turbo_confirm: t('.delete_image_confirm') }
-          = t('.delete_image')
+        .relative.inline-block.mt-2
+          = image_tag @arrival.image,
+                  class: 'max-h-48 rounded',
+                  alt: t('.image_alt', station_name: @arrival.station.name_i18n)
+          div style='position:absolute; top:4px; right:4px;'
+            = link_to arrival_image_path(@arrival),
+                class: 'flex items-center justify-center p-1 bg-white bg-opacity-25 rounded',
+                aria: { label: t('.delete_image') },
+                data: { turbo_method: :delete, turbo_confirm: t('.delete_image_confirm') }
+              i.fa-solid.fa-xmark.text-gray-400
       - else
         div data-controller='image-preview'
-          img.max-h-48.max-w-full.rounded.mt-2.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
+          .relative.inline-block.mt-2
+            img.max-h-48.max-w-full.rounded.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
+            div style='position:absolute; top:4px; right:4px;'
+              = button_tag type: 'button',
+                  class: 'flex items-center justify-center p-1 bg-white bg-opacity-25 rounded hidden',
+                  aria: { label: t('.cancel_image') },
+                  data: { image_preview_target: 'cancelButton', action: 'click->image-preview#cancel' }
+                i.fa-solid.fa-xmark.text-gray-400
           label.cursor-pointer.link-important.mt-2 for='arrival_image' data-image-preview-target='addButton'
             = t('.add_image')
-          = button_tag t('.cancel_image'), type: 'button', class: 'block text-sm text-gray-400 underline mt-1 hover:text-black hidden', data: { image_preview_target: 'cancelButton', action: 'click->image-preview#cancel' }
           = f.file_field :image, class: 'hidden', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
     .text-center.my-2
       = f.submit t('shared.buttons.save'), class: 'btn-primary'

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -12,7 +12,7 @@
       - if @arrival.image.attachment&.persisted?
         .flex.justify-center.mt-2
           .relative.inline-block
-            = image_tag @arrival.image.variant(resize_to_limit: [240, nil]),
+            = image_tag @arrival.image.variant(resize_to_limit: [240, 400]),
                     class: 'rounded',
                     alt: t('.image_alt', station_name: @arrival.station.name_i18n)
             div style='position:absolute; top:4px; right:4px;'
@@ -25,7 +25,7 @@
         div data-controller='image-preview'
           .flex.justify-center.mt-2
             .relative.inline-block
-              img.rounded.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='240' data-image-preview-target='preview'
+              img.rounded.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='240' height='400' data-image-preview-target='preview'
               div style='position:absolute; top:4px; right:4px;'
                 = button_tag type: 'button',
                     class: 'flex items-center justify-center p-1 bg-gray-50 rounded hidden',

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -23,7 +23,7 @@
                 i.fa-solid.fa-xmark.text-base-black
       - else
         div data-controller='image-preview'
-          .flex.justify-center.mt-2
+          .flex.justify-center
             .relative.inline-block
               img.rounded.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='240' height='400' data-image-preview-target='preview'
               div style='position:absolute; top:4px; right:4px;'
@@ -32,7 +32,7 @@
                     aria: { label: t('.cancel_image') },
                     data: { image_preview_target: 'cancelButton', action: 'click->image-preview#cancel' }
                   i.fa-solid.fa-xmark.text-base-black
-          label.cursor-pointer.link-important.mt-2 for='arrival_image' data-image-preview-target='addButton'
+          label.cursor-pointer.text-sm.text-gray-400.underline.hover:text-black for='arrival_image' data-image-preview-target='addButton'
             = t('.add_image')
           = f.file_field :image, class: 'hidden', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
     .text-center.my-2

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -10,26 +10,28 @@
     = f.text_area :memo, class: 'inline w-full rounded border border-gray-300', placeholder: t('.memo_placeholder'), maxlength: 250, autofocus: true
     - if FeatureFlag.enabled?(:image_upload)
       - if @arrival.image.attachment&.persisted?
-        .relative.inline-block.mt-2
-          = image_tag @arrival.image,
-                  class: 'max-h-48 rounded',
-                  alt: t('.image_alt', station_name: @arrival.station.name_i18n)
-          div style='position:absolute; top:4px; right:4px;'
-            = link_to arrival_image_path(@arrival),
-                class: 'flex items-center justify-center p-1 bg-gray-50 rounded',
-                aria: { label: t('.delete_image') },
-                data: { turbo_method: :delete, turbo_confirm: t('.delete_image_confirm') }
-              i.fa-solid.fa-xmark.text-base-black
+        .flex.justify-center.mt-2
+          .relative.inline-block
+            = image_tag @arrival.image.variant(resize_to_limit: [240, nil]),
+                    class: 'rounded',
+                    alt: t('.image_alt', station_name: @arrival.station.name_i18n)
+            div style='position:absolute; top:4px; right:4px;'
+              = link_to arrival_image_path(@arrival),
+                  class: 'flex items-center justify-center p-1 bg-gray-50 rounded',
+                  aria: { label: t('.delete_image') },
+                  data: { turbo_method: :delete, turbo_confirm: t('.delete_image_confirm') }
+                i.fa-solid.fa-xmark.text-base-black
       - else
         div data-controller='image-preview'
-          .relative.inline-block.mt-2
-            img.max-h-48.max-w-full.rounded.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) data-image-preview-target='preview'
-            div style='position:absolute; top:4px; right:4px;'
-              = button_tag type: 'button',
-                  class: 'flex items-center justify-center p-1 bg-gray-50 rounded hidden',
-                  aria: { label: t('.cancel_image') },
-                  data: { image_preview_target: 'cancelButton', action: 'click->image-preview#cancel' }
-                i.fa-solid.fa-xmark.text-base-black
+          .flex.justify-center.mt-2
+            .relative.inline-block
+              img.rounded.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='240' data-image-preview-target='preview'
+              div style='position:absolute; top:4px; right:4px;'
+                = button_tag type: 'button',
+                    class: 'flex items-center justify-center p-1 bg-gray-50 rounded hidden',
+                    aria: { label: t('.cancel_image') },
+                    data: { image_preview_target: 'cancelButton', action: 'click->image-preview#cancel' }
+                  i.fa-solid.fa-xmark.text-base-black
           label.cursor-pointer.link-important.mt-2 for='arrival_image' data-image-preview-target='addButton'
             = t('.add_image')
           = f.file_field :image, class: 'hidden', data: { image_preview_target: 'input', action: 'change->image-preview#show' }

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -25,7 +25,7 @@
         div data-controller='image-preview'
           .flex.justify-center
             .relative.inline-block
-              img.rounded.my-4.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='240' height='400' data-image-preview-target='preview'
+              img.rounded.my-4.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='240' data-image-preview-target='preview'
               div style='position:absolute; top:4px; right:4px;'
                 = button_tag type: 'button',
                     class: 'flex items-center justify-center p-1 bg-gray-50 rounded hidden',

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -12,7 +12,7 @@
       - if @arrival.image.attachment&.persisted?
         .flex.justify-center
           .relative.inline-block.my-4
-            = image_tag @arrival.image.variant(resize_to_limit: [240, 400]),
+            = image_tag @arrival.image.variant(resize_to_limit: [280, 400]),
                     class: 'rounded',
                     alt: t('.image_alt', station_name: @arrival.station.name_i18n)
             div style='position:absolute; top:4px; right:4px;'
@@ -25,7 +25,7 @@
         div data-controller='image-preview'
           .flex.justify-center
             .relative.inline-block
-              img.rounded.my-4.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='240' data-image-preview-target='preview'
+              img.rounded.my-4.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='280' data-image-preview-target='preview'
               div style='position:absolute; top:4px; right:4px;'
                 = button_tag type: 'button',
                     class: 'flex items-center justify-center p-1 bg-gray-50 rounded hidden',

--- a/app/views/walk/arrivals/index.html.slim
+++ b/app/views/walk/arrivals/index.html.slim
@@ -26,4 +26,4 @@
             = raw Rinku.auto_link(simple_format(h(arrival.memo)), :all, 'target="_blank"')
             - # rubocop:enable Rails/OutputSafety
         - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
-          = image_tag arrival.image.variant(resize_to_limit: [240, 400]), class: 'rounded mt-2', alt: t('arrivals.arrival.image_alt', station_name: arrival.station.name_i18n)
+          = image_tag arrival.image.variant(resize_to_limit: [280, 400]), class: 'rounded mt-2', alt: t('arrivals.arrival.image_alt', station_name: arrival.station.name_i18n)

--- a/app/views/walk/arrivals/index.html.slim
+++ b/app/views/walk/arrivals/index.html.slim
@@ -25,3 +25,5 @@
             - # rubocop:disable Rails/OutputSafety
             = raw Rinku.auto_link(simple_format(h(arrival.memo)), :all, 'target="_blank"')
             - # rubocop:enable Rails/OutputSafety
+        - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
+          = image_tag arrival.image.variant(resize_to_limit: [240, 400]), class: 'rounded mt-2', alt: t('arrivals.arrival.image_alt', station_name: arrival.station.name_i18n)


### PR DESCRIPTION
## 概要

- 画像の削除・選択解除のテキストリンク/ボタンを、画像右上のバツボタン（Font Awesome `fa-xmark`）に変更
- 画像サイズを `variant(resize_to_limit: [240, 400])` で統一
- 一覧・履歴ページの表示順をメモ→画像に変更
- 到着履歴一覧ページ（`/walks/:id/arrivals`、`/public/walks/:id/arrivals`）に画像表示を追加
- `file_field` に `accept` 属性を追加（PNG/JPEG のみ）
- 画像の上下余白を調整

## 変更内容

- `arrivals/edit.html.slim`: 保存済み画像・プレビュー画像の右上にバツボタンを配置。編集画面は中央寄せ。画像追加ボタンのスタイルを削除ボタンに統一
- `arrivals/_arrival.html.slim`: 表示順をメモ→画像に変更。画像サイズを `variant` で統一
- `walk/arrivals/index.html.slim`: 画像表示を追加
- `image_preview_controller.js`: バツボタンの表示制御を整理

## テスト方法

- [x] 編集画面で保存済み画像の右上にバツボタンが表示されること
- [x] バツボタンを押すと確認ダイアログが表示され、削除できること
- [x] 編集画面で画像を選択するとプレビューが表示され、バツボタンで選択解除できること
- [x] ファイル選択ダイアログでPNG/JPEGのみ選択できること
- [x] 一覧画面でメモ→画像の順で表示されること
- [x] `/walks/:id/arrivals` と `/public/walks/:id/arrivals` で画像が表示されること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 画像プレビュー表示／キャンセル時のボタン表示切替の処理順を修正

* **スタイル**
  * 編集画面の画像削除をアイコン表示に変更しUIを簡素化
  * プレビューのレイアウトとキャンセル操作を改善
  * 詳細表示でメモと画像の表示順を調整
  * ファイル入力にPNG/JPEG制限を追加

* **新機能**
  * 到着情報一覧・詳細でリサイズ済み画像を表示し表示サイズを最適化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->