### PR TITLE
feat: 画像アップロード機能のベータ警告バナーを追加

### DIFF
--- a/app/views/arrivals/index.html.slim
+++ b/app/views/arrivals/index.html.slim
@@ -7,6 +7,13 @@
       span.text-sm.text-gray-600 #{@walk.publish ? Walk.human_attribute_name(:publish) : Walk.human_attribute_name(:unpublish)}
       = link_to edit_walk_path(@walk), class: 'text-gray-400 hover:text-black'
         i class='fa-solid fa-gear fa-lg'
+- if FeatureFlag.enabled?(:image_upload)
+  .p-4.mb-4.text-sm.text-yellow-800.rounded-lg.bg-yellow-50 role='alert'
+    p.font-bold.mb-2
+      i.fa-solid.fa-triangle-exclamation.mr-1
+      = t('.image_upload_beta_warning.beta_status')
+    p = t('.image_upload_beta_warning.deletion_risk')
+    p = t('.image_upload_beta_warning.backup_request')
 = turbo_frame_tag 'arrivals-list' do
   = render partial: 'arrivals/arrival', collection: @arrivals, as: :arrival, locals: { user: @user, arrivals: @arrivals }
 

--- a/config/locales/views/arrivals/en.yml
+++ b/config/locales/views/arrivals/en.yml
@@ -14,6 +14,10 @@ en:
       title: Arrival list
       history: Arrival history
       back_to_map: Back to map
+      image_upload_beta_warning:
+        beta_status: Image attachment is currently in beta
+        deletion_risk: As this feature is in testing, it may be turned off or images may be deleted without notice.
+        backup_request: Please make sure to back up any important images yourself.
     edit:
       memo_placeholder: Getting tired! Jealous of cyclists ><
       image_alt: "Image preview at %{station_name} station"

--- a/config/locales/views/arrivals/ja.yml
+++ b/config/locales/views/arrivals/ja.yml
@@ -14,6 +14,10 @@ ja:
       title: 到着一覧
       history: 到着履歴
       back_to_map: 地図に戻る
+      image_upload_beta_warning:
+        beta_status: 画像添付機能は現在テスト運用中です
+        deletion_risk: テスト中のため、予告なく機能をOFFにしたり画像を削除する場合があります。
+        backup_request: 画像のバックアップはご自身でお願いします。
     edit:
       memo_placeholder: 辛くなってきた！自転車が羨ましい><
       image_alt: "%{station_name}の画像プレビュー"

--- a/docs/requirements/image_upload.md
+++ b/docs/requirements/image_upload.md
@@ -7,9 +7,11 @@
 ## スコープ
 
 - 到着 1 件につき画像 1 枚を添付・削除できる
-- アップロード可能なファイル形式は PNG / JPEG のみ
-- アップロード時に画像サイズを制限する
+- アップロード可能なファイル形式は PNG / JPEG のみ（保存時に WebP へ自動変換）
+- アップロード時に画像サイズを 5MB 以下に制限する
+- 保存時に 400×400 以内にリサイズする
 - ストレージは Cloudflare R2 を使用する
+- `FeatureFlag.enabled?(:image_upload)` で機能の ON/OFF を制御する（段階リリース対応）
 
 ---
 
@@ -42,8 +44,9 @@
 
 ### コントローラー
 
-- `Arrivals::ImagesController` を新規作成（create / destroy のみ担当）
-- 既存の `ArrivalsController` には画像処理を混ぜない
+- 画像のアップロードは `ArrivalsController#update` で処理（`attach_image` メソッド経由）
+- 画像の削除は `Arrivals::ImagesController#destroy` で処理
+- 画像処理ロジックは `app/models/arrival/image.rb` の `Arrival::Image` モジュールに集約
 
 ### ストレージ設定
 
@@ -70,6 +73,12 @@ cloudflare:
 - `CLOUDFLARE_R2_BUCKET`
 
 使用 gem: `aws-sdk-s3`、`image_processing`、`ruby-vips`
+
+### フロントエンド
+
+- `app/javascript/controllers/image_preview_controller.js`（Stimulus）でファイル選択時のプレビューとキャンセルを実装
+- 画像添付フォームは `arrivals/edit` ビューに配置
+- 画像は `arrivals/index` ビューの各到着行に表示（最大 280×400 でリサイズ）
 
 ---
 


### PR DESCRIPTION
## 概要

画像アップロード機能の段階リリース対応として、ベータ版警告バナーの追加と要件定義書の更新を行いました。

## 変更内容

- `/arrivals` ページのタイトル下に警告バナーを追加
  - `FeatureFlag.enabled?(:image_upload)` が true の場合のみ表示
  - Font Awesome の `fa-triangle-exclamation` アイコンを使用
- 要件定義書（`docs/requirements/image_upload.md`）を実装の実態に合わせて更新
  - WebP 自動変換・5MB サイズ制限・400×400 リサイズを追記
  - コントローラー設計を実態に合わせて修正
  - FeatureFlag・Stimulus の記述を追加

## テスト方法

1. `FeatureFlag.enabled?(:image_upload)` が `true` の状態で `/arrivals` にアクセスし、警告バナーが表示されることを確認
2. `FeatureFlag.enabled?(:image_upload)` が `false` の状態でバナーが表示されないことを確認
3. 到着履歴一覧の表示に変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * 画像アップロード機能のベータ版警告メッセージを到着管理ページに追加しました。ユーザーに対して現在のベータ状態とデータのバックアップをお願いする内容を表示します。

* **ドキュメント**
  * 画像アップロード要件仕様を更新しました。対応形式、ファイルサイズ制限、画像リサイズ仕様を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->