### PR TITLE
fix: 画像アップロード時に元ファイルとWebPの両方がストレージに保存されるバグを修正

### DIFF
--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -27,7 +27,7 @@ class ArrivalsController < ApplicationController
   end
 
   def update
-    @arrival.assign_attributes(arrival_params)
+    @arrival.assign_attributes(arrival_params.except(:image))
     @arrival.attach_image(arrival_params[:image]) if arrival_params[:image]
 
     if @arrival.save

--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -6,7 +6,7 @@ class ArrivalsController < ApplicationController
   before_action :set_user, only: %i[index]
 
   def index
-    @arrivals = current_walk.arrivals.order(:created_at).includes(:station)
+    @arrivals = current_walk.arrivals.order(:created_at).includes(:station, image_attachment: :blob)
   end
 
   def show

--- a/app/controllers/arrivals_controller.rb
+++ b/app/controllers/arrivals_controller.rb
@@ -27,7 +27,7 @@ class ArrivalsController < ApplicationController
   end
 
   def update
-    @arrival.assign_attributes(arrival_params.except(:image))
+    @arrival.assign_attributes(arrival_params)
     @arrival.attach_image(arrival_params[:image]) if arrival_params[:image]
 
     if @arrival.save

--- a/app/controllers/public/walks/arrivals_controller.rb
+++ b/app/controllers/public/walks/arrivals_controller.rb
@@ -6,7 +6,7 @@ class Public::Walks::ArrivalsController < ApplicationController
 
   def index
     if @walk.publish
-      @arrivals = @walk.arrivals.order(:created_at).includes(:station)
+      @arrivals = @walk.arrivals.order(:created_at).includes(:station, image_attachment: :blob)
       @user = current_user
       render 'walk/arrivals/index'
     else

--- a/app/controllers/walk/arrivals_controller.rb
+++ b/app/controllers/walk/arrivals_controller.rb
@@ -10,7 +10,7 @@ class Walk::ArrivalsController < ApplicationController
   before_action :redirect_unless_walk_user, only: %i[index]
 
   def index
-    @arrivals = @walk.arrivals.order(:created_at).includes(:station)
+    @arrivals = @walk.arrivals.order(:created_at).includes(:station, image_attachment: :blob)
   end
 
   private

--- a/app/views/arrivals/_arrival.html.slim
+++ b/app/views/arrivals/_arrival.html.slim
@@ -19,7 +19,7 @@
           = raw Rinku.auto_link(simple_format(h(arrival.memo)), :all, 'target="_blank"')
 
       - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
-        = image_tag arrival.image.variant(resize_to_limit: [280, 400]), class: 'rounded mt-2', alt: t('.image_alt', station_name: arrival.station.name_i18n)
+        = image_tag arrival.image, class: 'rounded mt-2 w-[280px]', alt: t('.image_alt', station_name: arrival.station.name_i18n)
     = link_to edit_arrival_path(arrival), class: 'inline-block h-11 content-center' do
       .text-sm.h-8.link-important = t('shared.buttons.edit')
     - if deletable?(arrival:, arrivals:)

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -12,8 +12,8 @@
       - if @arrival.image.attachment&.persisted?
         .flex.justify-center
           .relative.inline-block.my-4
-            = image_tag @arrival.image.variant(resize_to_limit: [280, 400]),
-                    class: 'rounded',
+            = image_tag @arrival.image,
+                    class: 'rounded w-[280px]',
                     alt: t('.image_alt', station_name: @arrival.station.name_i18n)
             div style='position:absolute; top:4px; right:4px;'
               = link_to arrival_image_path(@arrival),

--- a/app/views/walk/arrivals/index.html.slim
+++ b/app/views/walk/arrivals/index.html.slim
@@ -26,4 +26,4 @@
             = raw Rinku.auto_link(simple_format(h(arrival.memo)), :all, 'target="_blank"')
             - # rubocop:enable Rails/OutputSafety
         - if FeatureFlag.enabled?(:image_upload) && arrival.image.attached?
-          = image_tag arrival.image.variant(resize_to_limit: [280, 400]), class: 'rounded mt-2', alt: t('arrivals.arrival.image_alt', station_name: arrival.station.name_i18n)
+          = image_tag arrival.image, class: 'rounded mt-2 w-[280px]', alt: t('arrivals.arrival.image_alt', station_name: arrival.station.name_i18n)


### PR DESCRIPTION
## 概要

画像をアップロードした際、表示時に variant が生成されてストレージに二重保存されてしまうバグを修正する。あわせて到着一覧での画像表示の N+1 クエリを解消する。

PoC: https://github.com/SuzukaHori/YamaNotes/pull/303

## 変更内容

**ストレージへの二重保存を修正**

ビューで `image.variant(resize_to_limit: [280, 400])` を使っていたため、画像を表示するたびに variant ファイルがストレージに生成・保存されていた。アップロード時にすでに 400×400 以内にリサイズ済みの WebP として保存されているため、`variant` を使わず blob を直接参照するよう変更し、表示サイズは `w-[280px]` で CSS 制御する。

**到着一覧の N+1 クエリを解消**

`includes(:station)` のみで `image_attachment` と `blob` が含まれていなかったため、一覧表示時に arrival ごとに `image.attached?` や blob 情報へのクエリが発生していた。`includes(:station, image_attachment: :blob)` に変更し、arrival 件数によらず2クエリで済むよう改善した。

## テスト方法

- [ ] 画像（JPEG または PNG）をアップロードし、ストレージに WebP ファイルが1つだけ保存されることを確認する
- [ ] 画像を表示しても variant ファイルが追加生成されないことを確認する
- [ ] 画像が 280px 幅で正しく表示されることを確認する
- [ ] 到着一覧表示時のクエリ数が arrival 件数に比例して増えないことを確認する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **バグ修正・改善**
  * 到着情報の読み込みパフォーマンスを最適化しました。

* **スタイル**
  * 到着情報の画像表示を更新し、固定幅（280px）で統一されるよう調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->