### PR TITLE
fix: 画像プレビューのバツボタン位置を既存画像と揃える

### DIFF
--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -25,8 +25,8 @@
         div data-controller='image-preview'
           .flex.justify-center
             .relative.inline-block
-              img.rounded.my-4.hidden src='' alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='280' data-image-preview-target='preview'
-              div style='position:absolute; top:4px; right:4px;'
+              img.rounded.my-4.hidden alt=t('.image_alt', station_name: @arrival.station.name_i18n) width='280' data-image-preview-target='preview'
+              div style='position:absolute; top:20px; right:4px;'
                 = button_tag type: 'button',
                     class: 'flex items-center justify-center p-1 bg-gray-50 rounded hidden',
                     aria: { label: t('.cancel_image') },


### PR DESCRIPTION
## 概要
画像アップロード機能のプレビュー表示において、バツボタンの位置が既存画像のバツボタンと異なっていた問題を修正する。

## 変更内容
- `img` に `my-4`（16px マージン）が付いているため、`position:absolute; top:4px` だと画像上端よりずれていた
- `top` を `20px`（= 16px + 4px）に変更し、既存画像のバツボタン位置と統一した
- 不要な `src=''` 属性を削除した

## テスト方法
- [x] 到着編集フォームで画像を選択し、プレビューのバツボタンが画像右上に正しく表示されること
- [x] 既存画像のバツボタンと位置が揃っていること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 画像プレビュー表示の不要な属性を削除
  * キャンセルボタンの表示位置を調整しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->