### PR TITLE
feat: 到着編集フォームの送信中にボタンを非活性化して「送信中...」を表示する

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -197,6 +197,14 @@
 
 @utility btn-primary {
   @apply inline-flex items-center justify-center px-6 py-2 bg-bright-orange-100 text-white rounded-lg shadow-sm transition-all duration-200 ease-out hover:bg-bright-orange-50 focus:outline-hidden focus:ring-3 focus:ring-red-400/75 h-11 cursor-pointer;
+
+  &:disabled {
+    @apply opacity-50 cursor-not-allowed;
+    .when-enabled { display: none; }
+    .when-disabled { display: initial; }
+  }
+
+  .when-disabled { display: none; }
 }
 
 @utility link-important {

--- a/app/views/arrivals/edit.html.slim
+++ b/app/views/arrivals/edit.html.slim
@@ -36,4 +36,6 @@
             = t('.add_image')
           = f.file_field :image, class: 'hidden', accept: 'image/png,image/jpeg', data: { image_preview_target: 'input', action: 'change->image-preview#show' }
     .text-center.my-2
-      = f.submit t('shared.buttons.save'), class: 'btn-primary'
+      = button_tag type: 'submit', class: 'btn-primary' do
+          span.when-enabled = t('shared.buttons.save')
+          span.when-disabled = t('shared.buttons.saving')

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -5,6 +5,7 @@ en:
       edit: Edit
       delete: Delete
       save: Save
+      saving: Saving...
       back: Back
       next: Next
       post_to_x: Post to

--- a/config/locales/views/shared/ja.yml
+++ b/config/locales/views/shared/ja.yml
@@ -5,6 +5,7 @@ ja:
       edit: 編集
       delete: 削除
       save: 保存
+      saving: 送信中...
       back: 戻る
       next: 進む
       post_to_x: にポストする


### PR DESCRIPTION
## 概要

画像アップロード付きフォームの送信に300〜650msかかるため、送信中に何も起きていないように見える問題を改善する。

## 変更内容

- 保存ボタンを送信中に非活性化（Turboが `disabled` 属性を自動付与する仕組みを活用）
- `disabled` 状態のときに「保存」→「送信中...」へテキストを切り替え
- `btn-primary` に `:disabled` スタイル（グレーアウト・カーソル変更）を追加

## テスト方法

1. 到着編集画面を開く
2. 画像あり・なし両方で「保存」ボタンをクリック
3. 送信中にボタンがグレーアウトし「送信中...」と表示されることを確認
4. 保存完了後に「保存」に戻ることを確認
5. バリデーションエラー時にもボタンが復活することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善点**
  * 送信ボタンの状態表示を改善しました。フォーム送信時に「保存中...」と表示され、ボタンは無効化されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->