### PR TITLE
feat: フッターにバグ報告・改善要望フォームへのリンクを追加する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,4 +4,8 @@ module ApplicationHelper
   def fontawesome_url
     ENV.fetch('FONTAWESOME_URL', nil)
   end
+
+  def feedback_form_url
+    'https://docs.google.com/forms/d/e/1FAIpQLSeWKVNjR0qv0WC--4SmcaddRCMbkdlvTJlOfWt29KE9dtM5gA/viewform'
+  end
 end

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -2,6 +2,7 @@ footer.bg-white.border-t.border-gray-200.text-xs.text-center.pt-4.pb-3
   ul.flex.justify-center.items-center.pb-2
     li.inline-block.px-4.hover:underline.hover:text-gray-400 = link_to t('.terms'), page_path('terms')
     li.inline-block.px-4.hover:underline.hover:text-gray-400 = link_to t('.privacy'), page_path('privacy')
+    li.inline-block.px-4.hover:underline.hover:text-gray-400 = link_to t('.feedback'), feedback_form_url, target: '_blank', rel: 'noopener'
     - if I18n.locale == :ja
       li.inline-block.px-4.hover:underline.hover:text-gray-400 = link_to t('.switch_to_english'), url_for(locale: :en)
     - else

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -3,6 +3,7 @@ footer.bg-white.border-t.border-gray-200.text-xs.text-center.pt-4.pb-3
     li.inline-block.px-4.hover:underline.hover:text-gray-400 = link_to t('.terms'), page_path('terms')
     li.inline-block.px-4.hover:underline.hover:text-gray-400 = link_to t('.privacy'), page_path('privacy')
     li.inline-block.px-4.hover:underline.hover:text-gray-400 = link_to t('.feedback'), feedback_form_url, target: '_blank', rel: 'noopener'
+  ul.flex.justify-center.items-center
     - if I18n.locale == :ja
       li.inline-block.px-4.hover:underline.hover:text-gray-400 = link_to t('.switch_to_english'), url_for(locale: :en)
     - else
@@ -10,7 +11,6 @@ footer.bg-white.border-t.border-gray-200.text-xs.text-center.pt-4.pb-3
     li.text-xl.px-4.hover:text-gray-400
       = link_to 'https://github.com/SuzukaHori/YamaNotes', target: '_blank', rel: 'noopener'
         i.fa-brands.fa-github
-  ul.flex.justify-center.items-center
     li.px-4
       p.inline.pr-2 © 2024
       = link_to 'suzuka_hori', 'https://x.com/suzuka_hori', target: '_blank', rel: 'noopener', class: 'hover:underline hover:text-gray-400'

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -5,6 +5,7 @@ en:
       terms: Terms of Service
       privacy: Privacy Policy
       switch_to_japanese: 日本語
+      feedback: Bug Report / Feedback
     header:
       logout: Log out
       logout_confirm: Are you sure you want to log out?

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -5,7 +5,7 @@ en:
       terms: Terms of Service
       privacy: Privacy Policy
       switch_to_japanese: 日本語
-      feedback: Bug Report / Feedback
+      feedback: Feedback
     header:
       logout: Log out
       logout_confirm: Are you sure you want to log out?

--- a/config/locales/views/layouts/ja.yml
+++ b/config/locales/views/layouts/ja.yml
@@ -5,6 +5,7 @@ ja:
       terms: 利用規約
       privacy: プライバシーポリシー
       switch_to_english: English
+      feedback: バグ報告・改善要望
     header:
       logout: ログアウト
       logout_confirm: ログアウトします。よろしいですか？

--- a/config/locales/views/layouts/ja.yml
+++ b/config/locales/views/layouts/ja.yml
@@ -5,7 +5,7 @@ ja:
       terms: 利用規約
       privacy: プライバシーポリシー
       switch_to_english: English
-      feedback: バグ報告・改善要望
+      feedback: フィードバック
     header:
       logout: ログアウト
       logout_confirm: ログアウトします。よろしいですか？


### PR DESCRIPTION
## 概要
フッターに Google フォームへのリンクを追加し、ユーザーがフィードバックを送りやすくする。

## 変更内容
- `app/helpers/application_helper.rb`: フォーム URL を返す `feedback_form_url` ヘルパーメソッドを追加
- `app/views/layouts/_footer.html.slim`: フッターを2行構成に整理し「フィードバック」リンクを追加
  - 1行目：利用規約 / プライバシーポリシー / フィードバック
  - 2行目：言語切り替え / GitHub / © suzuka_hori
- `config/locales/views/layouts/ja.yml`: `feedback: フィードバック` を追加
- `config/locales/views/layouts/en.yml`: `feedback: Feedback` を追加

## テスト方法
- `bin/dev` でサーバーを起動
- フッターに「フィードバック」リンクが表示されることを確認
- クリックすると Google フォームが別タブで開くことを確認
- `?locale=en` で英語表示 "Feedback" になることを確認