### PR TITLE
image_preview_controller.js の lint 指摘を修正（セミコロン追加）

### DIFF
--- a/app/javascript/controllers/image_preview_controller.js
+++ b/app/javascript/controllers/image_preview_controller.js
@@ -1,27 +1,27 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["input", "preview", "addButton", "cancelButton"]
+  static targets = ["input", "preview", "addButton", "cancelButton"];
 
   show() {
-    const file = this.inputTarget.files[0]
-    if (!file) return
+    const file = this.inputTarget.files[0];
+    if (!file) return;
 
-    const reader = new FileReader()
+    const reader = new FileReader();
     reader.onload = (e) => {
-      this.previewTarget.src = e.target.result
-      this.previewTarget.classList.remove("hidden")
-      this.cancelButtonTarget.classList.remove("hidden")
-      this.addButtonTarget.classList.add("hidden")
-    }
-    reader.readAsDataURL(file)
+      this.previewTarget.src = e.target.result;
+      this.previewTarget.classList.remove("hidden");
+      this.cancelButtonTarget.classList.remove("hidden");
+      this.addButtonTarget.classList.add("hidden");
+    };
+    reader.readAsDataURL(file);
   }
 
   cancel() {
-    this.inputTarget.value = ""
-    this.previewTarget.src = ""
-    this.previewTarget.classList.add("hidden")
-    this.cancelButtonTarget.classList.add("hidden")
-    this.addButtonTarget.classList.remove("hidden")
+    this.inputTarget.value = "";
+    this.previewTarget.src = "";
+    this.previewTarget.classList.add("hidden");
+    this.cancelButtonTarget.classList.add("hidden");
+    this.addButtonTarget.classList.remove("hidden");
   }
 }


### PR DESCRIPTION
## 概要
ESLint の指摘に従い、`image_preview_controller.js` の全文にセミコロンを追加した。

## 変更内容
- `app/javascript/controllers/image_preview_controller.js` の各文末にセミコロンを追加

## テスト方法
- [x] `bin/lint` がエラーなしで通ること
- [x] 画像プレビュー機能（画像選択→プレビュー表示・キャンセル）が正常に動作すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * コード内の構文形式を統一し、一貫性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->