### PR TITLE
FontAwesomeの依存を完全に削除する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,5 @@
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
-# https://fontawesome.com/
-FONTAWESOME_URL=https://kit.fontawesome.com/TODO.js
 # https://cloud.maptiler.com/account/keys/
 MAPTAILER_KEY=TODO

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem 'bootsnap', require: false
 gem 'devise'
 gem 'devise-i18n'
 gem 'dotenv-rails'
-gem 'font-awesome-sass'
 gem 'gon'
 gem 'high_voltage'
 gem 'image_processing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,8 +166,6 @@ GEM
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
-    font-awesome-sass (6.7.2)
-      sassc (~> 2.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     gon (7.0.0)
@@ -444,8 +442,6 @@ GEM
       ffi (~> 1.12)
       logger
     rubyzip (3.2.2)
-    sassc (2.4.0)
-      ffi (~> 1.9)
     securerandom (0.4.1)
     selenium-webdriver (4.43.0)
       base64 (~> 0.2)
@@ -571,7 +567,6 @@ DEPENDENCIES
   dockerfile-rails
   dotenv-rails
   factory_bot_rails
-  font-awesome-sass
   gon
   high_voltage
   i18n_generators

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ https://www.yamanotes.com
 | :---: | :---:|
 | GOOGLE_CLIENT_ID | GoogleのクライアントID  |
 | GOOGLE_CLIENT_SECRET  | Googleのクライアントシークレット |
-| FONTAWESOME_URL | Font AwesomeのCDNコード |
 | MAPTAILER_KEY | MapTailerのアクセストークン |
 
 ## インストールと起動

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def fontawesome_url
-    ENV.fetch('FONTAWESOME_URL', nil)
-  end
-
   def feedback_form_url
     'https://docs.google.com/forms/d/e/1FAIpQLSeWKVNjR0qv0WC--4SmcaddRCMbkdlvTJlOfWt29KE9dtM5gA/viewform'
   end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -26,5 +26,4 @@ html lang=I18n.locale class='text-base-black'
     script[src='https://unpkg.com/leaflet@1.6.0/dist/leaflet.js'
       integrity='sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew=='
       crossorigin='']
-    script[async src="#{fontawesome_url}" crossorigin='']
     = render 'layouts/google_analytics'


### PR DESCRIPTION
## 概要

PR #343 でアイコンをSVGに置き換えたため、FontAwesome関連の残存コードと依存gemを完全に削除した。

## 変更内容

- `Gemfile` / `Gemfile.lock`: `font-awesome-sass`（および依存の`sassc`）を削除
- `app/helpers/application_helper.rb`: `fontawesome_url` ヘルパーメソッドを削除
- `app/views/layouts/application.html.slim`: FontAwesome CDN読み込み `<script>` タグを削除
- `README.md`: `FONTAWESOME_URL` 環境変数の説明を削除
- `.env.example`: `FONTAWESOME_URL` のエントリを削除

## テスト方法

- [x] `bundle install` が正常に完了すること
- [x] アプリを起動して各画面のアイコンが正しく表示されること（SVGに置き換え済みのもの）
- [x] ブラウザのネットワークタブでFontAwesome CDNへのリクエストが発生していないこと