### PR TITLE
dependabotをパッチ無視・週次スケジュールに変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "bundler" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "bundler"
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"


### PR DESCRIPTION
## 概要
dependabot の設定を変更し、パッチアップデートは無視してマイナー・メジャーアップデートのみPRを作成するようにした。あわせてスケジュールを週次に変更。

## 変更内容
- スケジュールを `daily` → `weekly` に変更
- `semver-patch` のアップデートを無視する設定を追加

## テスト方法
- [ ] `.github/dependabot.yml` の内容が正しいことを確認
- [ ] 次回のdependabot実行でパッチアップデートのPRが作成されないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係の自動更新スケジュールを毎日から週1回に変更しました
  * パッチレベルの自動更新を無視する設定を追加し、より安定した更新管理を実現しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->