### PR TITLE
環境変数によるメンテナンスモードを追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :render_maintenance, if: :maintenance?
   before_action :authenticate_user!
   around_action :switch_locale
   helper_method :current_walk
@@ -14,6 +15,14 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def maintenance?
+    ENV['MAINTENANCE'] == '1'
+  end
+
+  def render_maintenance
+    render 'pages/maintenance', layout: false, status: :service_unavailable
+  end
 
   def switch_locale(&action)
     locale = params[:locale]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  around_action :switch_locale
   before_action :render_maintenance, if: :maintenance?
   before_action :authenticate_user!
-  around_action :switch_locale
   helper_method :current_walk
 
   # 現在実施中の歩行を返す

--- a/app/views/pages/maintenance.html.slim
+++ b/app/views/pages/maintenance.html.slim
@@ -1,0 +1,44 @@
+doctype html
+html class='text-base-black'
+  head
+    title = t('pages.maintenance.title')
+    meta name='viewport' content='width=device-width,initial-scale=1'
+    meta name='robots' content='noindex'
+    css:
+      html {
+        color: #4f4f64;
+      }
+      body {
+        background-color: #F1FAEE;
+        max-width: 640px;
+        margin: 0 auto;
+        min-height: 100vh;
+      }
+      main {
+        padding-bottom: 0.5rem;
+        flex: 1;
+        background-color: #FFFFFF;
+      }
+      .container {
+        margin: 2rem auto;
+        padding: 2rem;
+        text-align: center;
+        font-size: 1.125rem;
+        max-width: 66.6667%;
+      }
+      .container h1 {
+        font-size: 1.25rem;
+        font-weight: bold;
+      }
+      .container h2 {
+        margin-bottom: 2rem;
+      }
+      .container p {
+        font-size: 1rem;
+      }
+  body
+    main
+      .container
+        h1 = t('pages.maintenance.heading')
+        h2 = t('pages.maintenance.status_code')
+        p = t('pages.maintenance.body')

--- a/config/locales/views/pages/en.yml
+++ b/config/locales/views/pages/en.yml
@@ -1,6 +1,11 @@
 ---
 en:
   pages:
+    maintenance:
+      title: Under Maintenance
+      heading: We are currently under maintenance
+      body: The system is currently undergoing maintenance. We apologize for the inconvenience. Please wait a while and try accessing again.
+      status_code: 503 Service Unavailable
     terms:
       title: Terms of Service
       meta_description: This is the Terms of Service page.

--- a/config/locales/views/pages/ja.yml
+++ b/config/locales/views/pages/ja.yml
@@ -1,6 +1,11 @@
 ---
 ja:
   pages:
+    maintenance:
+      title: メンテナンス中
+      heading: ただいまメンテナンス中です
+      body: 現在、システムのメンテナンスを実施しています。ご不便をおかけしますが、しばらくお待ちいただいてからもう一度アクセスしてください。
+      status_code: 503 Service Unavailable
     terms:
       title: 利用規約
       meta_description: 利用規約のページです。

--- a/docs/requirements/maintenance_mode.md
+++ b/docs/requirements/maintenance_mode.md
@@ -1,0 +1,52 @@
+# メンテナンスモード要件定義書
+
+## 概要
+
+システムのメンテナンス作業時に、環境変数だけで全ユーザーからのアクセスを一時的に遮断し、メンテナンス中の案内ページ（503）を表示できるようにする。
+
+## スコープ
+
+- 環境変数 `MAINTENANCE=1` のときにメンテナンスモードを有効化する（`0`・未設定は無効）
+- メンテナンスモード中は、`ApplicationController` を継承する全コントローラのリクエストに対して HTTP 503 とメンテナンス案内ページを返す
+- 認証（`authenticate_user!`）より前に遮断するため、未ログインでもメンテナンスページを表示する
+- ヘルスチェック用エンドポイント `/up`（`Rails::HealthController`。`ApplicationController` を継承しない）は対象外となり、メンテナンス中も 200 を返す
+- デプロイ先は VPS / 自前サーバーを前提とする（Heroku 等のプラットフォーム機能には依存しない）
+
+## スコープ外
+
+- 特定 IP のみアクセスを許可する仕組み（将来必要になれば追加する）
+- 管理画面からの ON/OFF 切り替え（環境変数の設定・再起動で運用する）
+- アクセス集中時の 503（従来どおり `public/503.html` が使われる。メンテナンスとは別物）
+
+---
+
+## 実装方式
+
+`ApplicationController` の `before_action` で環境変数を判定し、有効時はメンテナンスページをレンダリングして処理を打ち切る。
+
+- `authenticate_user!` より前に宣言することで、認証前に遮断し、未ログインでもメンテナンスページを表示する
+- 静的ページ（HighVoltage）や各コントローラは全て `ApplicationController` を継承するため、まとめて遮断できる
+
+## 挙動
+
+| 環境変数 | 対象 | 応答 |
+|---|---|---|
+| `MAINTENANCE` 未設定 / `0` | すべて | 通常どおり処理する |
+| `MAINTENANCE=1` | `ApplicationController` 継承下の全アクション | 503 + メンテナンスページ |
+| `MAINTENANCE=1` | `/up`（ヘルスチェック） | 200（対象外） |
+
+## 構成ファイル
+
+- `app/controllers/application_controller.rb` — `maintenance?` 判定と `render_maintenance`
+- `app/views/pages/maintenance.html.slim` — メンテナンス案内ページ（レイアウトなし）
+- `config/locales/views/pages/{ja,en}.yml` — メンテナンスページの文言
+
+## 運用手順
+
+```bash
+# メンテナンス開始（環境変数を設定して再起動）
+MAINTENANCE=1 でアプリを起動 / 再起動する
+
+# メンテナンス終了
+MAINTENANCE を 0 または未設定に戻して再起動する
+```

--- a/docs/requirements/maintenance_mode.md
+++ b/docs/requirements/maintenance_mode.md
@@ -26,6 +26,7 @@
 
 - `authenticate_user!` より前に宣言することで、認証前に遮断し、未ログインでもメンテナンスページを表示する
 - 静的ページ（HighVoltage）や各コントローラは全て `ApplicationController` を継承するため、まとめて遮断できる
+- `around_action :switch_locale` は `render_maintenance` より**前**に登録する。`render_maintenance` が render するとコールバックチェーンが打ち切られるため、後に登録すると `I18n.with_locale` が適用されず、メンテナンスページに `params[:locale]` が反映されない
 
 ## 挙動
 
@@ -34,6 +35,8 @@
 | `MAINTENANCE` 未設定 / `0` | すべて | 通常どおり処理する |
 | `MAINTENANCE=1` | `ApplicationController` 継承下の全アクション | 503 + メンテナンスページ |
 | `MAINTENANCE=1` | `/up`（ヘルスチェック） | 200（対象外） |
+
+メンテナンスページは通常ページと同様に `params[:locale]` に応じた言語（ja / en）で表示される。
 
 ## 構成ファイル
 


### PR DESCRIPTION
## 概要
環境変数 `MAINTENANCE=1` を設定するだけでメンテナンスモードに切り替えられるようにしました。有効時は全ページで 503 メンテナンスページを返します。

## 変更内容
- `ApplicationController` に `before_action :render_maintenance, if: :maintenance?` を追加（`authenticate_user!` より前に宣言し、認証前に遮断）
- `MAINTENANCE=1` で有効・`0`／未設定で無効（`ENV['MAINTENANCE'] == '1'` で判定）
- メンテナンスページ `app/views/pages/maintenance.html.slim` を追加（既存の 404 ページとデザインを統一）
- ja/en の文言を `config/locales/views/pages/` に追加
- ヘルスチェック `/up`（`Rails::HealthController`）は `ApplicationController` を継承しないため対象外（メンテ中も 200）
- 要件定義書 `docs/requirements/maintenance_mode.md` を追加

## テスト方法
- [ ] `MAINTENANCE=1 bin/dev` で起動し、任意のページにアクセスして 503 メンテナンスページが表示されること
- [ ] 未ログイン状態でもログイン画面ではなくメンテナンスページが表示されること
- [ ] `MAINTENANCE=1` のまま `/up` にアクセスすると 200 が返ること
- [ ] `MAINTENANCE=0` または未設定で起動すると通常どおりアクセスできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * メンテナンスモード時（`MAINTENANCE=1`）に、サイト全体を 503 のメンテナンス案内ページで表示します。
  * メンテナンスページに日本語・英語の文言を追加しました。
* **改善**
  * メンテナンス画面用の専用レイアウト／スタイルを適用し、noindex とメタ情報も設定しました。
  * ロケールに応じた表示に対応しました。
* **ドキュメント**
  * メンテナンスモードの要件と運用手順を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->