### PR TITLE
ボタンのカーソルを pointer に戻す

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -116,6 +116,18 @@
   }
 }
 
+/*
+  Tailwind CSS v4 の Preflight は button のカーソルを default にするため、
+  v3 までと同様に pointer へ戻す。
+  https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor
+*/
+@layer base {
+  button:not(:disabled),
+  [role='button']:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
 /* time_select: WebKit の日時フィールド pseudo-element の余分な padding を除去 */
 @layer base {
   ::-webkit-datetime-edit-fields-wrapper { padding: 0; }


### PR DESCRIPTION
## 概要

カーソルを当てた際にポインターにならないアイコン（ヘッダーのアイコン、メモのバツマークなど）を修正する。

Closes #386

## 背景・原因

Tailwind CSS v4 の Preflight の仕様変更により、`button` 要素のデフォルトカーソルが `pointer` から `default` に変わった（ブラウザのデフォルトスタイルに合わせる方針のため）。

- 公式アップグレードガイド: [Buttons use the default cursor](https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor)

このため、`cursor-pointer` を明示していないボタンだけがポインターにならない状態だった。

- ヘッダーのアイコン（ヘルプ・ユーザーメニュー・ハンバーガーメニュー）
- メモ／ヘルプダイアログのバツマーク
- `btn-primary` や `link-important` は utility 内で `cursor-pointer` を指定しているため影響なし

## 変更内容

- `app/assets/tailwind/application.css` に、公式アップグレードガイド推奨のベーススタイルを追加し、v3 までと同様に全ボタンのカーソルを pointer に戻した

```css
@layer base {
  button:not(:disabled),
  [role='button']:not(:disabled) {
    cursor: pointer;
  }
}
```

- `:not(:disabled)` により、無効化されたボタン（`btn-primary` の disabled 時 `cursor-not-allowed`）には影響しない

## テスト方法

- [x] ログイン後、ヘッダーのヘルプ・ユーザー・メニューアイコンにカーソルを当てるとポインターになる
- [x] 到着一覧からメモダイアログを開き、バツマークにカーソルを当てるとポインターになる
- [x] ヘルプダイアログのバツマークも同様にポインターになる
- [x] 無効化された保存ボタン（disabled 状態の `btn-primary`）は引き続き `cursor-not-allowed` のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)